### PR TITLE
Handle doc-less loogle hits without errors

### DIFF
--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -752,7 +752,7 @@ def loogle(ctx: Context, query: str, num_results: int = 8) -> List[dict] | str:
 
         results = results["hits"][:num_results]
         for result in results:
-            result.pop("doc")
+            result.pop("doc", None)
         return results
     except Exception as e:
         return f"loogle error:\n{str(e)}"


### PR DESCRIPTION
Retarget of fork PR #14 to upstream/main.

Original PR (on fork): https://github.com/eliasjudin/lean-lsp-mcp/pull/14

Base: oOo0oOo/lean-lsp-mcp:main
Head: eliasjudin:pr-f33f5d5

## Summary
- Tolerate doc-less responses from loogle by making the `doc` field removal optional.

## Rationale
Some loogle search results omit documentation. Dropping the key without a default raised a `KeyError`, preventing the entire batch from being returned. This change keeps the happy path intact while allowing doc-free hits through.

## Testing
- `uv run pytest -q tests/unit/test_server.py tests/test_search_tools.py`
