### PR TITLE
Fix list-returning tools producing double-encoded JSON

### DIFF
--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -11,12 +11,20 @@ from tests.helpers.mcp_client import MCPClient, result_text
 
 
 def _first_json_block(result) -> dict[str, str] | None:
+    """Extract the first JSON object from tool result.
+
+    Handles both JSON arrays (returns first element) and JSON objects.
+    """
     for block in result.content:
         text = getattr(block, "text", "").strip()
         if not text:
             continue
         try:
-            return orjson.loads(text)
+            parsed = orjson.loads(text)
+            # If it's a list, return the first element
+            if isinstance(parsed, list):
+                return parsed[0] if parsed else None
+            return parsed
         except orjson.JSONDecodeError:
             continue
     return None


### PR DESCRIPTION
FastMCP's `_convert_to_content` flattens lists into separate `TextContent` blocks, causing confusing serialized output for list-returning tools.

This fix:
- Add `_to_json_array()` helper to serialize lists as single JSON strings
- Update 9 affected tools to return `str` instead of `List[...]`:
  - `lean_diagnostic_messages`
  - `lean_multi_attempt`
  - `lean_run_code`
  - `lean_local_search`
  - `lean_leansearch`
  - `lean_loogle`
  - `lean_leanfinder`
  - `lean_state_search`
  - `lean_hammer_premise`
- Update test helper to handle JSON arrays

Fixes #76