### PR TITLE
Add CI workflow for linting and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
       - run: uv sync --extra lint
-      - run: uv run ruff check src/
-      - run: uv run ruff format --check src/
+      - run: uv run ruff check src/ tests/
+      - run: uv run ruff format --check src/ tests/
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs on PRs and pushes to main. Includes a lint job (ruff check and format verification) and a test job (pytest unit tests across Python 3.10-3.13).

Closes #86