### PR TITLE
ci: Add scheduled/manual workflow for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,9 +16,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install elan
-        run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+        run: curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
+
+      - name: Add elan to PATH
+        run: echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
       - uses: astral-sh/setup-uv@v4
         with:


### PR DESCRIPTION
Adds a new GitHub Actions workflow that runs integration tests:

- **Scheduled**: Runs weekly on Sundays at 00:00 UTC
- **Manual**: Can be triggered via workflow_dispatch

The workflow sets up Lean with elan, builds the test project with Mathlib cache, and runs the full test suite including integration tests.

Closes #90