### PR TITLE
feat: add opt-in Lean client prewarm on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ This MCP server works out-of-the-box without any configuration. However, a few o
 - `LEAN_LOG_LEVEL`: Log level for the server. Options are "INFO", "WARNING", "ERROR", "NONE". Defaults to "INFO".
 - `LEAN_LOG_FILE_CONFIG`: Config file path for logging, with priority over `LEAN_LOG_LEVEL`. If not set, logs are printed to stdout.
 - `LEAN_PROJECT_PATH`: Path to your Lean project root. Set this if the server cannot automatically detect your project.
+- `LEAN_LSP_PREWARM`: Set to `true`, `1`, or `yes` to prewarm the Lean LSP client during startup when `LEAN_PROJECT_PATH` is set (default: off).
 - `LEAN_REPL`: Set to `true`, `1`, or `yes` to enable fast REPL-based `lean_multi_attempt` (~5x faster, see [REPL Setup](#repl-setup)).
 - `LEAN_REPL_PATH`: Path to the `repl` binary. Auto-detected from `.lake/packages/repl/` if not set.
 - `LEAN_REPL_TIMEOUT`: Per-command timeout in seconds (default: 60).

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -144,7 +144,7 @@ _LEAN_LSP_PREWARM_ENV = "LEAN_LSP_PREWARM"
 
 
 def _env_flag_enabled(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes")
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
 
 
 @dataclass
@@ -234,7 +234,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
                 request_context=SimpleNamespace(lifespan_context=context)
             )
             try:
-                startup_client(prewarm_ctx)
+                await asyncio.to_thread(startup_client, prewarm_ctx)
             except Exception as exc:
                 logger.warning("Lean client prewarm failed: %s", exc)
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -115,6 +115,32 @@ async def test_app_lifespan_prewarm_failure_is_non_fatal(
     assert "Lean client prewarm failed" in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_app_lifespan_prewarm_accepts_on_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    monkeypatch.setenv("LEAN_PROJECT_PATH", str(project_dir))
+    monkeypatch.setenv("LEAN_LSP_PREWARM", "on")
+
+    called = {"count": 0}
+
+    def fake_startup(ctx: types.SimpleNamespace) -> None:
+        called["count"] += 1
+        assert (
+            ctx.request_context.lifespan_context.lean_project_path
+            == project_dir.resolve()
+        )
+
+    monkeypatch.setattr(server, "startup_client", fake_startup)
+
+    async with server.app_lifespan(object()):
+        pass
+
+    assert called["count"] == 1
+
+
 def test_rate_limited_allows_within_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     times = iter([100, 101])
     monkeypatch.setattr(server.time, "time", lambda: next(times))


### PR DESCRIPTION
Revives the closed prewarm thread from #42 in a safer form: opt-in only, default off.

## What changed
- Added `LEAN_LSP_PREWARM` flag parsing (`true|1|yes`) in server startup.
- When enabled and `LEAN_PROJECT_PATH` is set, lifespan prewarms the Lean client once.
- Prewarm failures are logged as warnings and do not fail server startup.
- Hardened lifespan shutdown path when context is not fully initialized.
- Added unit tests for enabled prewarm and failure-tolerant behavior.
- Documented `LEAN_LSP_PREWARM` in README environment variables.

## Why
Closed #42 identified a valid use case (reduce first LSP call latency), but startup-time tradeoffs were a concern. This implementation keeps default behavior unchanged and makes prewarm explicitly opt-in.

## Validation
- `uv run ruff check src/lean_lsp_mcp/server.py tests/unit/test_server.py`
- `uv run ruff format --check src/lean_lsp_mcp/server.py tests/unit/test_server.py`
- `uv run pytest tests/unit/test_server.py -q`
