### PR TITLE
feat: add optional auto-build fallback for Lean startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ This MCP server works out-of-the-box without any configuration. However, a few o
 - `LEAN_LOG_LEVEL`: Log level for the server. Options are "INFO", "WARNING", "ERROR", "NONE". Defaults to "INFO".
 - `LEAN_LOG_FILE_CONFIG`: Config file path for logging, with priority over `LEAN_LOG_LEVEL`. If not set, logs are printed to stdout.
 - `LEAN_PROJECT_PATH`: Path to your Lean project root. Set this if the server cannot automatically detect your project.
+- `LEAN_LSP_AUTO_BUILD`: Controls automatic retry with initial build when first Lean client startup fails. Defaults to enabled; set `0`, `false`, `no`, or `off` to disable.
 - `LEAN_REPL`: Set to `true`, `1`, or `yes` to enable fast REPL-based `lean_multi_attempt` (~5x faster, see [REPL Setup](#repl-setup)).
 - `LEAN_REPL_PATH`: Path to the `repl` binary. Auto-detected from `.lake/packages/repl/` if not set.
 - `LEAN_REPL_TIMEOUT`: Per-command timeout in seconds (default: 60).

--- a/src/lean_lsp_mcp/client_utils.py
+++ b/src/lean_lsp_mcp/client_utils.py
@@ -12,6 +12,8 @@ from lean_lsp_mcp.utils import OutputCapture
 
 logger = get_logger(__name__)
 CLIENT_LOCK = Lock()
+AUTO_BUILD_ENV = "LEAN_LSP_AUTO_BUILD"
+_AUTO_BUILD_FALSE_VALUES = {"0", "false", "no", "off"}
 
 
 def startup_client(ctx: Context):
@@ -38,14 +40,49 @@ def startup_client(ctx: Context):
         # Need to create a new client
         # In test environments, prevent repeated cache downloads
         prevent_cache = bool(os.environ.get("LEAN_LSP_TEST_MODE"))
-        with OutputCapture() as output:
-            client = LeanLSPClient(
-                lean_project_path, initial_build=False, prevent_cache_get=prevent_cache
+
+        startup_capture = OutputCapture()
+        try:
+            with startup_capture:
+                client = LeanLSPClient(
+                    lean_project_path,
+                    initial_build=False,
+                    prevent_cache_get=prevent_cache,
+                )
+        except Exception as first_error:
+            startup_output = startup_capture.get_output().strip()
+            auto_build_raw = os.environ.get(AUTO_BUILD_ENV, "1").strip().lower()
+            auto_build_enabled = auto_build_raw not in _AUTO_BUILD_FALSE_VALUES
+            if not auto_build_enabled:
+                msg = (
+                    "Failed to start Lean language server. "
+                    "Run `lake build` in your project manually and try again."
+                )
+                if startup_output:
+                    msg = f"{msg}\n\nStartup output:\n{startup_output}"
+                raise RuntimeError(msg) from first_error
+
+            logger.warning(
+                "Initial Lean startup failed (%s). Retrying with initial build; set %s=0 to disable.",
+                first_error,
+                AUTO_BUILD_ENV,
             )
-            logger.info(f"Connected to Lean language server at {lean_project_path}")
-        build_output = output.get_output()
-        if build_output:
-            logger.debug(f"Build output: {build_output}")
+            build_capture = OutputCapture()
+            with build_capture:
+                client = LeanLSPClient(
+                    lean_project_path,
+                    initial_build=True,
+                    prevent_cache_get=prevent_cache,
+                )
+            build_output = build_capture.get_output().strip()
+            if build_output:
+                logger.info("Initial build output:\n%s", build_output)
+        else:
+            startup_output = startup_capture.get_output().strip()
+            if startup_output:
+                logger.debug("Lean startup output:\n%s", startup_output)
+
+        logger.info(f"Connected to Lean language server at {lean_project_path}")
         ctx.request_context.lifespan_context.client = client
 
 


### PR DESCRIPTION
Revives the startup fallback thread from closed #51 in a focused, test-covered patch.

## What changed
- Added `LEAN_LSP_AUTO_BUILD` handling in `startup_client`.
- First startup attempt still uses `initial_build=False` (fast path).
- On failure, startup now retries with `initial_build=True` by default.
- Auto-build fallback can be disabled with `LEAN_LSP_AUTO_BUILD=0|false|no|off`.
- When disabled, startup raises a clear error instructing the user to run `lake build`.
- Added unit tests for both fallback-enabled and fallback-disabled behavior.
- Documented `LEAN_LSP_AUTO_BUILD` in README.

## Why
In closed #51, startup fallback logic was useful but got dropped in a larger lifecycle patch. This PR extracts the high-value, low-risk part into a small standalone change.

## Validation
- `uv run ruff check src/lean_lsp_mcp/client_utils.py tests/unit/test_client_utils.py`
- `uv run ruff format --check src/lean_lsp_mcp/client_utils.py tests/unit/test_client_utils.py`
- `uv run pytest tests/unit/test_client_utils.py -q`
