### PR TITLE
Add slim local semantic search tool (no lockfile churn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Semantic search over local declarations using embeddings. This tool indexes your
 Requires optional dependencies:
 
 ```bash
-uv add --optional semantic-search sentence-transformers numpy
+uv sync --extra semantic-search
 ```
 
 Environment variables:

--- a/README.md
+++ b/README.md
@@ -308,6 +308,22 @@ This is useful to confirm declarations actually exist and prevent hallucinating 
 
 This tool requires [ripgrep](https://github.com/BurntSushi/ripgrep?tab=readme-ov-file#installation) (`rg`) to be installed and available in your PATH.
 
+#### lean_local_semantic_search
+
+Semantic search over local declarations using embeddings. This tool indexes your project and dependencies locally.
+
+Requires optional dependencies:
+
+```bash
+uv add --optional semantic-search sentence-transformers numpy
+```
+
+Environment variables:
+
+- `LEAN_SEMANTIC_SEARCH_MODEL`: Embedding model name (default: `sentence-transformers/all-MiniLM-L6-v2`).
+- `LEAN_SEMANTIC_SEARCH_CACHE_DIR`: Override cache directory for the semantic index.
+- `LEAN_SEMANTIC_SEARCH_REBUILD`: Set to `true`, `1`, or `yes` to force a rebuild.
+
 ### External Search Tools
 
 Currently most external tools are separately **rate limited to 3 requests per 30 seconds**. Please don't ruin the fun for everyone by overusing these amazing free services!
@@ -473,6 +489,9 @@ This MCP server works out-of-the-box without any configuration. However, a few o
 - `LEAN_HAMMER_URL`: URL for a self-hosted [Lean Hammer Premise Search](https://github.com/hanwenzhu/lean-premise-server) instance.
 - `LEAN_LOOGLE_LOCAL`: Set to `true`, `1`, or `yes` to enable local loogle (see [Local Loogle](#local-loogle) section).
 - `LEAN_LOOGLE_CACHE_DIR`: Override the cache directory for local loogle (default: `~/.cache/lean-lsp-mcp/loogle`).
+- `LEAN_SEMANTIC_SEARCH_MODEL`: Embedding model name for local semantic search.
+- `LEAN_SEMANTIC_SEARCH_CACHE_DIR`: Cache directory for semantic search indices.
+- `LEAN_SEMANTIC_SEARCH_REBUILD`: Force rebuild of the semantic search index.
 
 You can also often set these environment variables in your MCP client configuration:
 <details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ Repository = "https://github.com/oOo0oOo/lean-lsp-mcp"
 [project.optional-dependencies]
 yaml = ["PyYAML>=6.0"]
 lint = ["ruff>=0.2.0"]
+semantic-search = ["numpy>=1.26.0", "sentence-transformers>=3.0.0"]
 dev = ["ruff>=0.2.0", "pytest>=8.3", "anyio>=4.4", "pytest-asyncio>=0.23", "pytest-timeout>=2.3"]
 
 [tool.ruff]

--- a/src/lean_lsp_mcp/instructions.py
+++ b/src/lean_lsp_mcp/instructions.py
@@ -8,6 +8,7 @@ INSTRUCTIONS = """## General Rules
 - **lean_hover_info**: Type signature + docs. Column at START of identifier.
 - **lean_completions**: IDE autocomplete on incomplete code.
 - **lean_local_search**: Fast local declaration search. Use BEFORE trying a lemma name.
+- **lean_local_semantic_search**: Local semantic search over declarations (requires optional deps).
 - **lean_file_outline**: Token-efficient file skeleton (slow-ish).
 - **lean_multi_attempt**: Test tactics without editing: `["simp", "ring", "omega"]`
 - **lean_declaration_file**: Get declaration source. Use sparingly (large output).
@@ -24,6 +25,7 @@ INSTRUCTIONS = """## General Rules
 
 ## Search Decision Tree
 1. "Does X exist locally?" -> lean_local_search
+1. "Find semantically related local declarations" -> lean_local_semantic_search
 2. "I need a lemma that says X" -> lean_leansearch
 3. "Find lemma with type pattern" -> lean_loogle
 4. "What's the Lean name for concept X?" -> lean_leanfinder

--- a/src/lean_lsp_mcp/instructions.py
+++ b/src/lean_lsp_mcp/instructions.py
@@ -25,12 +25,12 @@ INSTRUCTIONS = """## General Rules
 
 ## Search Decision Tree
 1. "Does X exist locally?" -> lean_local_search
-1. "Find semantically related local declarations" -> lean_local_semantic_search
-2. "I need a lemma that says X" -> lean_leansearch
-3. "Find lemma with type pattern" -> lean_loogle
-4. "What's the Lean name for concept X?" -> lean_leanfinder
-5. "What closes this goal?" -> lean_state_search
-6. "What to feed simp?" -> lean_hammer_premise
+2. "Find semantically related local declarations" -> lean_local_semantic_search
+3. "I need a lemma that says X" -> lean_leansearch
+4. "Find lemma with type pattern" -> lean_loogle
+5. "What's the Lean name for concept X?" -> lean_leanfinder
+6. "What closes this goal?" -> lean_state_search
+7. "What to feed simp?" -> lean_hammer_premise
 
 After finding a name: lean_local_search to verify, lean_hover_info for signature.
 

--- a/src/lean_lsp_mcp/models.py
+++ b/src/lean_lsp_mcp/models.py
@@ -38,6 +38,15 @@ class PremiseResult(BaseModel):
     name: str = Field(description="Premise name for simp/omega/aesop")
 
 
+class SemanticSearchResult(BaseModel):
+    name: str = Field(description="Declaration name")
+    kind: str = Field(description="Declaration kind")
+    file: str = Field(description="Relative file path")
+    line: int = Field(description="Line number (1-indexed)")
+    score: float = Field(description="Similarity score")
+    snippet: str = Field(description="Matched declaration snippet")
+
+
 class DiagnosticMessage(BaseModel):
     severity: str = Field(description="error, warning, info, or hint")
     message: str = Field(description="Diagnostic message text")
@@ -210,6 +219,14 @@ class PremiseResults(BaseModel):
 
     items: List[PremiseResult] = Field(
         default_factory=list, description="List of premise results"
+    )
+
+
+class SemanticSearchResults(BaseModel):
+    """Wrapper for semantic search results list."""
+
+    items: List[SemanticSearchResult] = Field(
+        default_factory=list, description="List of semantic search results"
     )
 
 

--- a/src/lean_lsp_mcp/semantic_search.py
+++ b/src/lean_lsp_mcp/semantic_search.py
@@ -158,7 +158,7 @@ def _load_model(model_name: str):
     except Exception as exc:
         raise LeanToolError(
             "Semantic search requires sentence-transformers. "
-            "Install with `uv add --optional semantic-search sentence-transformers numpy`."
+            "Install with `uv add sentence-transformers numpy`."
         ) from exc
 
     return SentenceTransformer(model_name)
@@ -170,7 +170,7 @@ def _require_numpy():
     except Exception as exc:
         raise LeanToolError(
             "Semantic search requires numpy. "
-            "Install with `uv add --optional semantic-search sentence-transformers numpy`."
+            "Install with `uv add sentence-transformers numpy`."
         ) from exc
     return np
 

--- a/src/lean_lsp_mcp/semantic_search.py
+++ b/src/lean_lsp_mcp/semantic_search.py
@@ -40,6 +40,10 @@ def _hash_token(value: str) -> str:
     return sha256(value.encode("utf-8")).hexdigest()[:12]
 
 
+def _content_hash(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
 def _index_prefix(project_root: Path, model_name: str) -> str:
     return f"{_hash_token(str(project_root))}-{_hash_token(model_name)}"
 
@@ -75,27 +79,18 @@ def _list_lean_files(project_root: Path) -> list[Path]:
     return [Path(line.strip()) for line in result.stdout.splitlines() if line.strip()]
 
 
-def _extract_decls(file_path: Path, project_root: Path) -> Iterable[SemanticSearchItem]:
-    try:
-        text = file_path.read_text(encoding="utf-8")
-    except Exception:
-        return []
-
-    items = []
+def _extract_decls_from_text(text: str, rel_file: str) -> list[SemanticSearchItem]:
+    items: list[SemanticSearchItem] = []
     for idx, line in enumerate(text.splitlines(), start=1):
         match = _DECL_PATTERN.match(line)
         if not match:
             continue
         kind, name = match.group(1), match.group(2)
-        try:
-            rel = file_path.relative_to(project_root)
-        except ValueError:
-            rel = file_path
         items.append(
             SemanticSearchItem(
                 name=name,
                 kind=kind,
-                file=str(rel),
+                file=rel_file,
                 line=idx,
                 snippet=line.strip(),
             )
@@ -103,18 +98,29 @@ def _extract_decls(file_path: Path, project_root: Path) -> Iterable[SemanticSear
     return items
 
 
-def _collect_items(project_root: Path) -> tuple[list[SemanticSearchItem], float]:
-    files = _list_lean_files(project_root)
-    items: list[SemanticSearchItem] = []
-    latest_mtime = 0.0
-    for file_path in files:
+def _extract_decls(file_path: Path, project_root: Path) -> Iterable[SemanticSearchItem]:
+    try:
+        text = file_path.read_text(encoding="utf-8")
+    except Exception:
+        return []
+
+    try:
+        rel = file_path.relative_to(project_root)
+    except ValueError:
+        rel = file_path
+    return _extract_decls_from_text(text, str(rel))
+
+
+def _list_file_states(project_root: Path) -> dict[str, tuple[Path, int, int]]:
+    states: dict[str, tuple[Path, int, int]] = {}
+    for file_path in _list_lean_files(project_root):
         try:
             stat = file_path.stat()
-            latest_mtime = max(latest_mtime, stat.st_mtime)
-        except FileNotFoundError:
+            rel = str(file_path.relative_to(project_root))
+        except (FileNotFoundError, OSError, ValueError):
             continue
-        items.extend(_extract_decls(file_path, project_root))
-    return items, latest_mtime
+        states[rel] = (file_path, stat.st_mtime_ns, stat.st_size)
+    return states
 
 
 def _load_index(index_dir: Path, prefix: str):
@@ -124,25 +130,43 @@ def _load_index(index_dir: Path, prefix: str):
         return None
 
     meta = json.loads(meta_path.read_text(encoding="utf-8"))
-    items = [SemanticSearchItem(**item) for item in meta["items"]]
-    latest_mtime = meta["latest_mtime"]
+    items = [SemanticSearchItem(**item) for item in meta.get("items", [])]
+
+    file_states: dict[str, dict[str, int | str]] = {}
+    raw_states = meta.get("file_states", {})
+    if isinstance(raw_states, dict):
+        for rel, value in raw_states.items():
+            if not isinstance(rel, str) or not isinstance(value, dict):
+                continue
+            mtime_ns = int(value.get("mtime_ns", 0))
+            size = int(value.get("size", 0))
+            content_hash = str(value.get("content_hash", ""))
+            file_states[rel] = {
+                "mtime_ns": mtime_ns,
+                "size": size,
+                "content_hash": content_hash,
+            }
 
     import numpy as np
 
     embeddings = np.load(vec_path)
-    return items, embeddings, latest_mtime
+    return items, embeddings, file_states
 
 
 def _save_index(
-    index_dir: Path, prefix: str, items, embeddings, latest_mtime: float
+    index_dir: Path,
+    prefix: str,
+    items,
+    embeddings,
+    file_states: dict[str, dict[str, int | str]],
 ) -> None:
     index_dir.mkdir(parents=True, exist_ok=True)
     meta_path = index_dir / f"{prefix}.json"
     vec_path = index_dir / f"{prefix}.npy"
 
     meta = {
-        "latest_mtime": latest_mtime,
         "items": [item.__dict__ for item in items],
+        "file_states": file_states,
     }
     meta_path.write_text(json.dumps(meta), encoding="utf-8")
 
@@ -158,7 +182,7 @@ def _load_model(model_name: str):
     except Exception as exc:
         raise LeanToolError(
             "Semantic search requires sentence-transformers. "
-            "Install with `uv add sentence-transformers numpy`."
+            "Install with `uv sync --extra semantic-search` or `uv add sentence-transformers numpy`."
         ) from exc
 
     return SentenceTransformer(model_name)
@@ -170,9 +194,129 @@ def _require_numpy():
     except Exception as exc:
         raise LeanToolError(
             "Semantic search requires numpy. "
-            "Install with `uv add sentence-transformers numpy`."
+            "Install with `uv sync --extra semantic-search` or `uv add sentence-transformers numpy`."
         ) from exc
     return np
+
+
+def _prepare_index(
+    *,
+    project_root: Path,
+    model_name: str,
+    rebuild: bool,
+):
+    index_dir = get_cache_dir()
+    prefix = _index_prefix(project_root, model_name)
+
+    loaded = None if rebuild else _load_index(index_dir, prefix)
+    if loaded is None:
+        current_states = _list_file_states(project_root)
+        changed_entries: list[tuple[str, str, int, int, str]] = []
+        for rel, (file_path, mtime_ns, size) in current_states.items():
+            try:
+                text = file_path.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            changed_entries.append((rel, text, mtime_ns, size, _content_hash(text)))
+
+        if not changed_entries:
+            return [], None
+
+        model = _load_model(model_name)
+        np = _require_numpy()
+
+        new_items: list[SemanticSearchItem] = []
+        for rel, text, *_ in changed_entries:
+            new_items.extend(_extract_decls_from_text(text, rel))
+
+        if not new_items:
+            return [], None
+
+        texts = [f"{item.name} {item.kind} {item.snippet}" for item in new_items]
+        embeddings = np.array(model.encode(texts, normalize_embeddings=True))
+
+        next_states = {
+            rel: {"mtime_ns": mtime_ns, "size": size, "content_hash": content_hash}
+            for rel, _text, mtime_ns, size, content_hash in changed_entries
+        }
+        _save_index(index_dir, prefix, new_items, embeddings, next_states)
+        return new_items, embeddings
+
+    items, embeddings, previous_states = loaded
+
+    current_states = _list_file_states(project_root)
+    removed_files = set(previous_states) - set(current_states)
+
+    changed_entries: list[tuple[str, str, int, int, str]] = []
+    next_states: dict[str, dict[str, int | str]] = {}
+    touched_without_content_change = False
+
+    for rel, (file_path, mtime_ns, size) in current_states.items():
+        prev = previous_states.get(rel)
+        if prev and prev.get("mtime_ns") == mtime_ns and prev.get("size") == size:
+            next_states[rel] = prev
+            continue
+
+        try:
+            text = file_path.read_text(encoding="utf-8")
+        except Exception:
+            removed_files.add(rel)
+            continue
+
+        content_hash = _content_hash(text)
+        if prev and prev.get("content_hash") == content_hash:
+            touched_without_content_change = True
+            next_states[rel] = {
+                "mtime_ns": mtime_ns,
+                "size": size,
+                "content_hash": content_hash,
+            }
+            continue
+
+        changed_entries.append((rel, text, mtime_ns, size, content_hash))
+        next_states[rel] = {
+            "mtime_ns": mtime_ns,
+            "size": size,
+            "content_hash": content_hash,
+        }
+
+    if not removed_files and not changed_entries:
+        if touched_without_content_change and items:
+            _save_index(index_dir, prefix, items, embeddings, next_states)
+        return items, embeddings
+
+    drop_files = removed_files | {rel for rel, *_ in changed_entries}
+    keep_indices = [idx for idx, item in enumerate(items) if item.file not in drop_files]
+    kept_items = [items[idx] for idx in keep_indices]
+
+    np = _require_numpy()
+    if keep_indices:
+        kept_embeddings = embeddings[keep_indices]
+    else:
+        kept_embeddings = None
+
+    new_items: list[SemanticSearchItem] = []
+    for rel, text, *_ in changed_entries:
+        new_items.extend(_extract_decls_from_text(text, rel))
+
+    if new_items:
+        model = _load_model(model_name)
+        new_texts = [f"{item.name} {item.kind} {item.snippet}" for item in new_items]
+        new_embeddings = np.array(model.encode(new_texts, normalize_embeddings=True))
+
+        if kept_embeddings is None:
+            merged_embeddings = new_embeddings
+        else:
+            merged_embeddings = np.vstack([kept_embeddings, new_embeddings])
+        merged_items = kept_items + new_items
+    else:
+        if kept_embeddings is None:
+            return [], None
+        merged_embeddings = kept_embeddings
+        merged_items = kept_items
+
+    _save_index(index_dir, prefix, merged_items, merged_embeddings, next_states)
+    return merged_items, merged_embeddings
 
 
 def local_semantic_search(
@@ -183,29 +327,13 @@ def local_semantic_search(
     model_name: str,
     rebuild: bool,
 ) -> list[tuple[SemanticSearchItem, float]]:
-    index_dir = get_cache_dir()
-    prefix = _index_prefix(project_root, model_name)
+    items, embeddings = _prepare_index(
+        project_root=project_root,
+        model_name=model_name,
+        rebuild=rebuild,
+    )
 
-    items, embeddings, latest_mtime = None, None, None
-
-    if not rebuild:
-        loaded = _load_index(index_dir, prefix)
-        if loaded is not None:
-            items, embeddings, latest_mtime = loaded
-
-    current_items, current_mtime = _collect_items(project_root)
-    if items is None or latest_mtime is None or current_mtime > latest_mtime:
-        model = _load_model(model_name)
-        np = _require_numpy()
-        texts = [f"{item.name} {item.kind} {item.snippet}" for item in current_items]
-        if not texts:
-            return []
-        embeddings = model.encode(texts, normalize_embeddings=True)
-        embeddings = np.array(embeddings)
-        _save_index(index_dir, prefix, current_items, embeddings, current_mtime)
-        items = current_items
-
-    if not items:
+    if not items or embeddings is None:
         return []
 
     model = _load_model(model_name)

--- a/src/lean_lsp_mcp/semantic_search.py
+++ b/src/lean_lsp_mcp/semantic_search.py
@@ -1,0 +1,222 @@
+"""Local semantic search using embeddings over Lean declarations."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from functools import lru_cache
+from hashlib import sha256
+from pathlib import Path
+from typing import Iterable
+
+from lean_lsp_mcp.search_utils import check_ripgrep_status
+from lean_lsp_mcp.utils import LeanToolError
+
+_DECL_PATTERN = re.compile(
+    r"^\s*(theorem|lemma|def|axiom|class|instance|structure|inductive|abbrev|opaque)\s+([A-Za-z0-9_'.]+)"
+)
+
+
+@dataclass(frozen=True)
+class SemanticSearchItem:
+    name: str
+    kind: str
+    file: str
+    line: int
+    snippet: str
+
+
+def get_cache_dir() -> Path:
+    if d := os.environ.get("LEAN_SEMANTIC_SEARCH_CACHE_DIR"):
+        return Path(d)
+    xdg = os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")
+    return Path(xdg) / "lean-lsp-mcp" / "semantic-search"
+
+
+def _hash_token(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _index_prefix(project_root: Path, model_name: str) -> str:
+    return f"{_hash_token(str(project_root))}-{_hash_token(model_name)}"
+
+
+def _list_lean_files(project_root: Path) -> list[Path]:
+    ok, msg = check_ripgrep_status()
+    if not ok:
+        raise LeanToolError(msg)
+
+    command = [
+        "rg",
+        "--files",
+        "--hidden",
+        "-g",
+        "*.lean",
+        "-g",
+        "!.git/**",
+        "-g",
+        "!.lake/build/**",
+        str(project_root),
+    ]
+
+    result = subprocess.run(
+        command,
+        cwd=str(project_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        raise LeanToolError(result.stderr.strip() or "Failed to list Lean files")
+
+    return [Path(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+
+
+def _extract_decls(file_path: Path, project_root: Path) -> Iterable[SemanticSearchItem]:
+    try:
+        text = file_path.read_text(encoding="utf-8")
+    except Exception:
+        return []
+
+    items = []
+    for idx, line in enumerate(text.splitlines(), start=1):
+        match = _DECL_PATTERN.match(line)
+        if not match:
+            continue
+        kind, name = match.group(1), match.group(2)
+        try:
+            rel = file_path.relative_to(project_root)
+        except ValueError:
+            rel = file_path
+        items.append(
+            SemanticSearchItem(
+                name=name,
+                kind=kind,
+                file=str(rel),
+                line=idx,
+                snippet=line.strip(),
+            )
+        )
+    return items
+
+
+def _collect_items(project_root: Path) -> tuple[list[SemanticSearchItem], float]:
+    files = _list_lean_files(project_root)
+    items: list[SemanticSearchItem] = []
+    latest_mtime = 0.0
+    for file_path in files:
+        try:
+            stat = file_path.stat()
+            latest_mtime = max(latest_mtime, stat.st_mtime)
+        except FileNotFoundError:
+            continue
+        items.extend(_extract_decls(file_path, project_root))
+    return items, latest_mtime
+
+
+def _load_index(index_dir: Path, prefix: str):
+    meta_path = index_dir / f"{prefix}.json"
+    vec_path = index_dir / f"{prefix}.npy"
+    if not meta_path.exists() or not vec_path.exists():
+        return None
+
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    items = [SemanticSearchItem(**item) for item in meta["items"]]
+    latest_mtime = meta["latest_mtime"]
+
+    import numpy as np
+
+    embeddings = np.load(vec_path)
+    return items, embeddings, latest_mtime
+
+
+def _save_index(
+    index_dir: Path, prefix: str, items, embeddings, latest_mtime: float
+) -> None:
+    index_dir.mkdir(parents=True, exist_ok=True)
+    meta_path = index_dir / f"{prefix}.json"
+    vec_path = index_dir / f"{prefix}.npy"
+
+    meta = {
+        "latest_mtime": latest_mtime,
+        "items": [item.__dict__ for item in items],
+    }
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+    import numpy as np
+
+    np.save(vec_path, embeddings)
+
+
+@lru_cache(maxsize=1)
+def _load_model(model_name: str):
+    try:
+        from sentence_transformers import SentenceTransformer
+    except Exception as exc:
+        raise LeanToolError(
+            "Semantic search requires sentence-transformers. "
+            "Install with `uv add --optional semantic-search sentence-transformers numpy`."
+        ) from exc
+
+    return SentenceTransformer(model_name)
+
+
+def _require_numpy():
+    try:
+        import numpy as np
+    except Exception as exc:
+        raise LeanToolError(
+            "Semantic search requires numpy. "
+            "Install with `uv add --optional semantic-search sentence-transformers numpy`."
+        ) from exc
+    return np
+
+
+def local_semantic_search(
+    *,
+    query: str,
+    project_root: Path,
+    limit: int,
+    model_name: str,
+    rebuild: bool,
+) -> list[tuple[SemanticSearchItem, float]]:
+    index_dir = get_cache_dir()
+    prefix = _index_prefix(project_root, model_name)
+
+    items, embeddings, latest_mtime = None, None, None
+
+    if not rebuild:
+        loaded = _load_index(index_dir, prefix)
+        if loaded is not None:
+            items, embeddings, latest_mtime = loaded
+
+    current_items, current_mtime = _collect_items(project_root)
+    if items is None or latest_mtime is None or current_mtime > latest_mtime:
+        model = _load_model(model_name)
+        np = _require_numpy()
+        texts = [f"{item.name} {item.kind} {item.snippet}" for item in current_items]
+        if not texts:
+            return []
+        embeddings = model.encode(texts, normalize_embeddings=True)
+        embeddings = np.array(embeddings)
+        _save_index(index_dir, prefix, current_items, embeddings, current_mtime)
+        items = current_items
+
+    if not items:
+        return []
+
+    model = _load_model(model_name)
+    np = _require_numpy()
+    query_vec = model.encode([query], normalize_embeddings=True)
+    query_vec = np.array(query_vec)[0]
+    scores = embeddings @ query_vec
+    top_idx = scores.argsort()[-limit:][::-1]
+
+    results: list[tuple[SemanticSearchItem, float]] = []
+    for idx in top_idx:
+        results.append((items[int(idx)], float(scores[int(idx)])))
+
+    return results

--- a/src/lean_lsp_mcp/semantic_search.py
+++ b/src/lean_lsp_mcp/semantic_search.py
@@ -175,52 +175,58 @@ def _require_numpy():
     return np
 
 
-def _prepare_index(
+def _build_fresh_index(
     *,
-    project_root: Path,
+    index_dir: Path,
+    prefix: str,
+    current_states: dict[str, tuple[Path, int, int]],
     model_name: str,
-    rebuild: bool,
 ):
-    index_dir = get_cache_dir()
-    prefix = _index_prefix(project_root, model_name)
+    changed_entries: list[tuple[str, str, int, int, str]] = []
+    for rel, (file_path, mtime_ns, size) in current_states.items():
+        try:
+            text = file_path.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        changed_entries.append((rel, text, mtime_ns, size, _content_hash(text)))
 
-    loaded = None if rebuild else _load_index(index_dir, prefix)
-    if loaded is None:
-        current_states = _list_file_states(project_root)
-        changed_entries: list[tuple[str, str, int, int, str]] = []
-        for rel, (file_path, mtime_ns, size) in current_states.items():
-            try:
-                text = file_path.read_text(encoding="utf-8")
-            except Exception:
-                continue
-            changed_entries.append((rel, text, mtime_ns, size, _content_hash(text)))
+    if not changed_entries:
+        return [], None
 
-        if not changed_entries:
-            return [], None
+    model = _load_model(model_name)
+    np = _require_numpy()
 
-        model = _load_model(model_name)
-        np = _require_numpy()
+    new_items: list[SemanticSearchItem] = []
+    for rel, text, *_ in changed_entries:
+        new_items.extend(_extract_decls_from_text(text, rel))
 
-        new_items: list[SemanticSearchItem] = []
-        for rel, text, *_ in changed_entries:
-            new_items.extend(_extract_decls_from_text(text, rel))
+    if not new_items:
+        return [], None
 
-        if not new_items:
-            return [], None
+    texts = [f"{item.name} {item.kind} {item.snippet}" for item in new_items]
+    embeddings = np.array(model.encode(texts, normalize_embeddings=True))
 
-        texts = [f"{item.name} {item.kind} {item.snippet}" for item in new_items]
-        embeddings = np.array(model.encode(texts, normalize_embeddings=True))
+    next_states = {
+        rel: {"mtime_ns": mtime_ns, "size": size, "content_hash": content_hash}
+        for rel, _text, mtime_ns, size, content_hash in changed_entries
+    }
+    _save_index(index_dir, prefix, new_items, embeddings, next_states)
+    return new_items, embeddings
 
-        next_states = {
-            rel: {"mtime_ns": mtime_ns, "size": size, "content_hash": content_hash}
-            for rel, _text, mtime_ns, size, content_hash in changed_entries
-        }
-        _save_index(index_dir, prefix, new_items, embeddings, next_states)
-        return new_items, embeddings
 
-    items, embeddings, previous_states = loaded
+def _update_index(
+    *,
+    index_dir: Path,
+    prefix: str,
+    current_states: dict[str, tuple[Path, int, int]],
+    loaded_items,
+    loaded_embeddings,
+    previous_states: dict[str, dict[str, int | str]],
+    model_name: str,
+):
+    items = loaded_items
+    embeddings = loaded_embeddings
 
-    current_states = _list_file_states(project_root)
     removed_files = set(previous_states) - set(current_states)
 
     changed_entries: list[tuple[str, str, int, int, str]] = []
@@ -293,6 +299,37 @@ def _prepare_index(
 
     _save_index(index_dir, prefix, merged_items, merged_embeddings, next_states)
     return merged_items, merged_embeddings
+
+
+def _prepare_index(
+    *,
+    project_root: Path,
+    model_name: str,
+    rebuild: bool,
+):
+    index_dir = get_cache_dir()
+    prefix = _index_prefix(project_root, model_name)
+    current_states = _list_file_states(project_root)
+
+    loaded = None if rebuild else _load_index(index_dir, prefix)
+    if loaded is None:
+        return _build_fresh_index(
+            index_dir=index_dir,
+            prefix=prefix,
+            current_states=current_states,
+            model_name=model_name,
+        )
+
+    items, embeddings, previous_states = loaded
+    return _update_index(
+        index_dir=index_dir,
+        prefix=prefix,
+        current_states=current_states,
+        loaded_items=items,
+        loaded_embeddings=embeddings,
+        previous_states=previous_states,
+        model_name=model_name,
+    )
 
 
 def local_semantic_search(

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -56,6 +56,8 @@ from lean_lsp_mcp.models import (
     PremiseResults,
     ProofProfileResult,
     RunResult,
+    SemanticSearchResult,
+    SemanticSearchResults,
     StateSearchResult,
     StateSearchResults,
     TermGoalState,
@@ -65,6 +67,7 @@ from lean_lsp_mcp.models import (
 # The model uses lean_multi_attempt which handles REPL internally.
 from lean_lsp_mcp.outline_utils import generate_outline_data
 from lean_lsp_mcp.search_utils import check_ripgrep_status, lean_local_search
+from lean_lsp_mcp.semantic_search import local_semantic_search
 from lean_lsp_mcp.utils import (
     COMPLETION_KIND,
     LeanToolError,
@@ -1147,6 +1150,72 @@ async def local_search(
         return LocalSearchResults(items=results)
     except RuntimeError as exc:
         raise LocalSearchError(f"Search failed: {exc}")
+
+
+@mcp.tool(
+    "lean_local_semantic_search",
+    annotations=ToolAnnotations(
+        title="Local Semantic Search",
+        readOnlyHint=True,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+async def local_semantic_search_tool(
+    ctx: Context,
+    query: Annotated[str, Field(description="Natural language query")],
+    limit: Annotated[int, Field(description="Max matches", ge=1)] = 10,
+    project_root: Annotated[
+        Optional[str], Field(description="Project root (inferred if omitted)")
+    ] = None,
+    model_name: Annotated[
+        Optional[str], Field(description="Embedding model name override")
+    ] = None,
+    rebuild: Annotated[bool, Field(description="Force rebuild semantic index")] = False,
+) -> SemanticSearchResults:
+    """Semantic search over local declarations using embeddings."""
+    if project_root:
+        root = Path(project_root).expanduser().resolve()
+    else:
+        root = ctx.request_context.lifespan_context.lean_project_path
+
+    if root is None:
+        raise LeanToolError(
+            "Lean project path not set. Provide project_root or call a file-based tool first."
+        )
+
+    model = model_name or os.environ.get(
+        "LEAN_SEMANTIC_SEARCH_MODEL", "sentence-transformers/all-MiniLM-L6-v2"
+    )
+    force_rebuild = rebuild or os.environ.get(
+        "LEAN_SEMANTIC_SEARCH_REBUILD", ""
+    ).lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+    results = await asyncio.to_thread(
+        local_semantic_search,
+        query=query.strip(),
+        project_root=root,
+        limit=limit,
+        model_name=model,
+        rebuild=force_rebuild,
+    )
+
+    items = [
+        SemanticSearchResult(
+            name=item.name,
+            kind=item.kind,
+            file=item.file,
+            line=item.line,
+            score=score,
+            snippet=item.snippet,
+        )
+        for item, score in results
+    ]
+    return SemanticSearchResults(items=items)
 
 
 @mcp.tool(

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -1195,6 +1195,12 @@ async def local_semantic_search_tool(
         "yes",
     )
 
+    await _safe_report_progress(
+        ctx,
+        progress=1,
+        total=3,
+        message="Preparing semantic index (first run may take longer)",
+    )
     results = await asyncio.to_thread(
         local_semantic_search,
         query=query.strip(),
@@ -1202,6 +1208,9 @@ async def local_semantic_search_tool(
         limit=limit,
         model_name=model,
         rebuild=force_rebuild,
+    )
+    await _safe_report_progress(
+        ctx, progress=3, total=3, message=f"Semantic search complete ({len(results)} hits)"
     )
 
     items = [

--- a/tests/unit/test_semantic_search.py
+++ b/tests/unit/test_semantic_search.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import builtins
 from pathlib import Path
+
+import pytest
 
 from lean_lsp_mcp import semantic_search
 
@@ -29,3 +32,36 @@ def test_index_prefix_stable(tmp_path: Path) -> None:
     model = "sentence-transformers/all-MiniLM-L6-v2"
     prefix = semantic_search._index_prefix(root, model)
     assert prefix.count("-") == 1
+
+
+def test_load_model_missing_dependency_shows_install_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "sentence_transformers":
+            raise ModuleNotFoundError("No module named 'sentence_transformers'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    semantic_search._load_model.cache_clear()
+
+    with pytest.raises(semantic_search.LeanToolError, match="uv add sentence-transformers numpy"):
+        semantic_search._load_model("sentence-transformers/all-MiniLM-L6-v2")
+
+
+def test_require_numpy_missing_dependency_shows_install_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "numpy":
+            raise ModuleNotFoundError("No module named 'numpy'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(semantic_search.LeanToolError, match="uv add sentence-transformers numpy"):
+        semantic_search._require_numpy()

--- a/tests/unit/test_semantic_search.py
+++ b/tests/unit/test_semantic_search.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from lean_lsp_mcp import semantic_search
+
+
+def test_extract_decls(tmp_path: Path) -> None:
+    file_path = tmp_path / "Sample.lean"
+    file_path.write_text(
+        """
+/-- doc -/\n
+theorem foo : True := by\n  trivial\n
+structure Bar where\n  x : Nat\n
+def baz := 1\n""",
+        encoding="utf-8",
+    )
+
+    items = list(semantic_search._extract_decls(file_path, tmp_path))
+    names = [item.name for item in items]
+    kinds = [item.kind for item in items]
+
+    assert names == ["foo", "Bar", "baz"]
+    assert kinds == ["theorem", "structure", "def"]
+
+
+def test_index_prefix_stable(tmp_path: Path) -> None:
+    root = tmp_path / "proj"
+    model = "sentence-transformers/all-MiniLM-L6-v2"
+    prefix = semantic_search._index_prefix(root, model)
+    assert prefix.count("-") == 1

--- a/tests/unit/test_semantic_search.py
+++ b/tests/unit/test_semantic_search.py
@@ -47,7 +47,9 @@ def test_load_model_missing_dependency_shows_install_hint(
     monkeypatch.setattr(builtins, "__import__", fake_import)
     semantic_search._load_model.cache_clear()
 
-    with pytest.raises(semantic_search.LeanToolError, match="uv add sentence-transformers numpy"):
+    with pytest.raises(
+        semantic_search.LeanToolError, match="uv add sentence-transformers numpy"
+    ):
         semantic_search._load_model("sentence-transformers/all-MiniLM-L6-v2")
 
 
@@ -63,5 +65,7 @@ def test_require_numpy_missing_dependency_shows_install_hint(
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
-    with pytest.raises(semantic_search.LeanToolError, match="uv add sentence-transformers numpy"):
+    with pytest.raises(
+        semantic_search.LeanToolError, match="uv add sentence-transformers numpy"
+    ):
         semantic_search._require_numpy()

--- a/tests/unit/test_semantic_search.py
+++ b/tests/unit/test_semantic_search.py
@@ -193,6 +193,90 @@ def test_prepare_index_uses_content_hash_for_touched_files(
     assert len(saved) == 1
 
 
+def test_prepare_index_dispatches_to_fresh_index_builder(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    file_path = project / "Sample.lean"
+    file_path.write_text("def foo := 1\n", encoding="utf-8")
+    stat = file_path.stat()
+    current_states = {"Sample.lean": (file_path, stat.st_mtime_ns, stat.st_size)}
+
+    monkeypatch.setattr(semantic_search, "_list_file_states", lambda _project_root: current_states)
+    monkeypatch.setattr(semantic_search, "_load_index", lambda _index_dir, _prefix: None)
+    monkeypatch.setattr(
+        semantic_search,
+        "_update_index",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("update path should not run without a cached index")
+        ),
+    )
+
+    called: dict[str, object] = {}
+
+    def fake_build_fresh_index(**kwargs):
+        called.update(kwargs)
+        return ["fresh"], "embeddings"
+
+    monkeypatch.setattr(semantic_search, "_build_fresh_index", fake_build_fresh_index)
+
+    items, embeddings = semantic_search._prepare_index(
+        project_root=project,
+        model_name="fake-model",
+        rebuild=False,
+    )
+
+    assert items == ["fresh"]
+    assert embeddings == "embeddings"
+    assert called["current_states"] == current_states
+    assert called["model_name"] == "fake-model"
+
+
+def test_prepare_index_dispatches_to_cached_index_updater(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    file_path = project / "Sample.lean"
+    file_path.write_text("def foo := 1\n", encoding="utf-8")
+    stat = file_path.stat()
+    current_states = {"Sample.lean": (file_path, stat.st_mtime_ns, stat.st_size)}
+    loaded = (["cached"], "embeddings", {"Sample.lean": {"mtime_ns": 1, "size": 12}})
+
+    monkeypatch.setattr(semantic_search, "_list_file_states", lambda _project_root: current_states)
+    monkeypatch.setattr(semantic_search, "_load_index", lambda _index_dir, _prefix: loaded)
+    monkeypatch.setattr(
+        semantic_search,
+        "_build_fresh_index",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("fresh path should not run when a cached index exists")
+        ),
+    )
+
+    called: dict[str, object] = {}
+
+    def fake_update_index(**kwargs):
+        called.update(kwargs)
+        return ["updated"], "new-embeddings"
+
+    monkeypatch.setattr(semantic_search, "_update_index", fake_update_index)
+
+    items, embeddings = semantic_search._prepare_index(
+        project_root=project,
+        model_name="fake-model",
+        rebuild=False,
+    )
+
+    assert items == ["updated"]
+    assert embeddings == "new-embeddings"
+    assert called["current_states"] == current_states
+    assert called["loaded_items"] == ["cached"]
+    assert called["loaded_embeddings"] == "embeddings"
+    assert called["previous_states"] == {"Sample.lean": {"mtime_ns": 1, "size": 12}}
+    assert called["model_name"] == "fake-model"
+
+
 class _FakeScores(list):
     def argsort(self):
         return sorted(range(len(self)), key=lambda idx: self[idx])


### PR DESCRIPTION
## Summary
- add `lean_local_semantic_search` for embedding-based local declaration search
- keep the feature self-contained and optional via runtime imports (no lockfile/dependency churn in this PR)
- add extraction/index tests for semantic search utilities

## Scope
This intentionally supersedes the heavier `#126` shape with a slim review surface.

## Validation
- `uv run ruff check src/lean_lsp_mcp/semantic_search.py src/lean_lsp_mcp/server.py src/lean_lsp_mcp/models.py src/lean_lsp_mcp/instructions.py tests/unit/test_semantic_search.py`
- `uv run --with pytest --with pytest-asyncio pytest tests/unit/test_semantic_search.py -q`
