### PR TITLE
Fix parse_axioms failing on multiline #print axioms output

### DIFF
--- a/src/lean_lsp_mcp/verify.py
+++ b/src/lean_lsp_mcp/verify.py
@@ -56,8 +56,8 @@ def parse_axioms(diagnostics: list[dict]) -> list[str]:
     for diag in diagnostics:
         if diag.get("severity") != 3:  # info
             continue
-        msg = diag.get("message", "")
-        if m := re.search(r"depends on axioms:\s*\[(.+)\]", msg):
+        msg = diag.get("message", "").replace("\n", " ")
+        if m := re.search(r"depends on axioms:\s*\[(.+?)\]", msg):
             axioms.extend(a.strip() for a in m.group(1).split(","))
     return axioms
 

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -43,6 +43,27 @@ class TestParseAxioms:
         diags = [{"severity": 1, "message": "'x' depends on axioms: [sorryAx]"}]
         assert parse_axioms(diags) == []
 
+    def test_multiline_axioms(self):
+        """Long declaration names cause #print axioms to wrap across lines."""
+        diags = [
+            {
+                "severity": 3,
+                "message": (
+                    "'Foo.integralTensorPower_coherentState_eq'"
+                    " depends on axioms: [propext,\n"
+                    " sorryAx,\n"
+                    " Classical.choice,\n"
+                    " Quot.sound]"
+                ),
+            }
+        ]
+        assert parse_axioms(diags) == [
+            "propext",
+            "sorryAx",
+            "Classical.choice",
+            "Quot.sound",
+        ]
+
     def test_empty(self):
         assert parse_axioms([]) == []
 


### PR DESCRIPTION
parse_axioms returns [] when #print axioms wraps across multiple lines. This happens with long declaration names:
'this_beautiful_theoOo0oOoOo0oOoOo0oOoOo0oOoOo0oOorem' depends on axioms: [propext,\n sorryAx,\n Classical.choice,\n Quot.sound]

The regex .+ doesn't match across \n.

Fix:  Normalize newlines to spaces before matching. Also made the capture group non-greedy (.+?).
Added test_multiline_axioms covering the wrapped output case. All 16 tests pass.