### PR TITLE
Rewrite lean_verify to use append-and-restore instead of olean files

### DIFF
--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -1154,56 +1154,62 @@ def verify_theorem(
     """Check theorem axioms + optional source scan. Only scans the given file, not imports."""
     from lean_lsp_mcp.verify import (
         check_axiom_errors,
-        make_axiom_check,
         parse_axioms,
         scan_warnings,
     )
 
-    lifespan = ctx.request_context.lifespan_context
-    project_path = lifespan.lean_project_path
-    if project_path is None:
-        infer_project_path(file_path, ctx=ctx)
-        project_path = lifespan.lean_project_path
-    if project_path is None:
-        raise LeanToolError("No Lean project found")
+    rel_path = setup_client_for_file(ctx, file_path)
+    if not rel_path:
+        raise LeanToolError(
+            "Invalid Lean file path: Unable to start LSP server or load file"
+        )
 
     abs_path = Path(file_path)
-    if not abs_path.exists():
-        raise LeanToolError(f"File not found: {file_path}")
+    client: LeanLSPClient = ctx.request_context.lifespan_context.client
+    client.open_file(rel_path)
 
     try:
-        rel_path, tmp_path = make_axiom_check(abs_path, project_path, theorem_name)
-    except (ValueError, OSError) as e:
-        raise LeanToolError(str(e))
+        original_content = client.get_file_content(rel_path)
+    except Exception:
+        original_content = get_file_contents(file_path)
 
-    client: LeanLSPClient | None = lifespan.client
-    opened = False
+    snippet = f"\n#print axioms {theorem_name}\n"
+    original_lines = original_content.split("\n")
+    appended_line = len(original_lines)  # 0-indexed line where snippet starts
+
     try:
-        if client is None:
-            startup_client(ctx)
-            client = lifespan.client
-        if client is None:
-            raise LeanToolError("Failed to initialize Lean client")
-        assert client is not None
-        client.open_file(rel_path)
-        opened = True
-        raw = client.get_diagnostics(rel_path, inactivity_timeout=15.0)
+        change = DocumentContentChange(
+            snippet,
+            [appended_line, 0],
+            [appended_line, 0],
+        )
+        client.update_file(rel_path, [change])
+        raw = client.get_diagnostics(
+            rel_path, start_line=appended_line, inactivity_timeout=120.0
+        )
         check_lsp_response(raw, "get_diagnostics")
+
+        appended_diags = list(raw)
+
+        if err := check_axiom_errors(appended_diags):
+            raise LeanToolError(f"Axiom check failed: {err}")
+
+        axioms = parse_axioms(appended_diags)
     finally:
-        if opened:
+        if original_content is not None:
             try:
-                client.close_files([rel_path])
+                client.update_file_content(rel_path, original_content)
             except Exception as exc:
-                logger.warning("Failed to close verify temp file: %s", exc)
-        try:
-            tmp_path.unlink()
-        except Exception:
-            pass
+                logger.warning(
+                    "Failed to restore `%s` after verify: %s", rel_path, exc
+                )
+            try:
+                client.open_file(rel_path, force_reopen=True)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to force-reopen `%s` after verify: %s", rel_path, exc
+                )
 
-    if err := check_axiom_errors(raw):
-        raise LeanToolError(f"Axiom check failed: {err}")
-
-    axioms = parse_axioms(raw)
     w: list[SourceWarning] = []
     if scan_source:
         if _RG_AVAILABLE:

--- a/src/lean_lsp_mcp/verify.py
+++ b/src/lean_lsp_mcp/verify.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 import subprocess
-import uuid
 from pathlib import Path
 
 from orjson import loads as _json_loads
@@ -27,27 +26,6 @@ _WARNING_PATTERNS: list[str] = [
 ]
 
 _COMBINED_PATTERN = "|".join(f"(?:{p})" for p in _WARNING_PATTERNS)
-
-
-def _cleanup_stale_verify_files(project_path: Path) -> None:
-    for f in project_path.glob("_mcp_verify_*.lean"):
-        try:
-            f.unlink()
-        except OSError:
-            pass
-
-
-def make_axiom_check(
-    file_path: Path, project_path: Path, theorem_name: str
-) -> tuple[str, Path]:
-    """Create temp file for axiom checking. Returns (rel_path, abs_path)."""
-    _cleanup_stale_verify_files(project_path)
-    rel = file_path.resolve().relative_to(project_path.resolve())
-    module = str(rel.with_suffix("")).replace("/", ".").replace("\\", ".")
-    rel_path = f"_mcp_verify_{uuid.uuid4().hex}.lean"
-    tmp = project_path / rel_path
-    tmp.write_text(f"import {module}\n#print axioms {theorem_name}\n", encoding="utf-8")
-    return rel_path, tmp
 
 
 def parse_axioms(diagnostics: list[dict]) -> list[str]:

--- a/src/lean_lsp_mcp/verify.py
+++ b/src/lean_lsp_mcp/verify.py
@@ -28,18 +28,6 @@ _WARNING_PATTERNS: list[str] = [
 _COMBINED_PATTERN = "|".join(f"(?:{p})" for p in _WARNING_PATTERNS)
 
 
-def make_axiom_check(
-    file_path: Path, project_path: Path, theorem_name: str
-) -> tuple[str, Path]:
-    """Create temp file for axiom checking. Returns (rel_path, abs_path)."""
-    rel = file_path.resolve().relative_to(project_path.resolve())
-    module = str(rel.with_suffix("")).replace("/", ".").replace("\\", ".")
-    rel_path = f"_mcp_verify_{uuid.uuid4().hex}.lean"
-    tmp = project_path / rel_path
-    tmp.write_text(f"import {module}\n#print axioms {theorem_name}\n", encoding="utf-8")
-    return rel_path, tmp
-
-
 def parse_axioms(diagnostics: list[dict]) -> list[str]:
     """Extract axiom names from #print axioms info diagnostics."""
     axioms: list[str] = []

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -9,7 +9,6 @@ import pytest
 
 from lean_lsp_mcp.verify import (
     check_axiom_errors,
-    make_axiom_check,
     parse_axioms,
     scan_warnings,
 )
@@ -82,43 +81,6 @@ class TestCheckAxiomErrors:
             {"severity": 1, "message": "b"},
         ]
         assert check_axiom_errors(diags) == "a; b"
-
-
-class TestMakeAxiomCheck:
-    def test_creates_temp_file(self, tmp_path: Path):
-        proj = tmp_path / "proj"
-        proj.mkdir()
-        (proj / "lean-toolchain").touch()
-        src = proj / "Foo.lean"
-        src.write_text("theorem bar : True := trivial\n")
-        rel_path, tmp = make_axiom_check(src, proj, "bar")
-        assert tmp.exists()
-        content = tmp.read_text()
-        assert "import Foo" in content
-        assert "#print axioms bar" in content
-        tmp.unlink()
-
-    def test_raises_on_outside_project(self, tmp_path: Path):
-        proj = tmp_path / "proj"
-        proj.mkdir()
-        outside = tmp_path / "other" / "Foo.lean"
-        outside.parent.mkdir()
-        outside.touch()
-        try:
-            make_axiom_check(outside, proj, "bar")
-            assert False, "Should have raised"
-        except ValueError:
-            pass
-
-    def test_cleans_stale_files(self, tmp_path: Path):
-        proj = tmp_path / "proj"
-        proj.mkdir()
-        src = proj / "Foo.lean"
-        src.write_text("theorem bar : True := trivial\n")
-        stale = proj / "_mcp_verify_deadbeef.lean"
-        stale.write_text("stale")
-        make_axiom_check(src, proj, "bar")
-        assert not stale.exists()
 
 
 class TestScanWarnings:

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -83,43 +83,6 @@ class TestCheckAxiomErrors:
         assert check_axiom_errors(diags) == "a; b"
 
 
-class TestMakeAxiomCheck:
-    def test_creates_temp_file(self, tmp_path: Path):
-        proj = tmp_path / "proj"
-        proj.mkdir()
-        (proj / "lean-toolchain").touch()
-        src = proj / "Foo.lean"
-        src.write_text("theorem bar : True := trivial\n")
-        rel_path, tmp = make_axiom_check(src, proj, "bar")
-        assert tmp.exists()
-        content = tmp.read_text()
-        assert "import Foo" in content
-        assert "#print axioms bar" in content
-        tmp.unlink()
-
-    def test_raises_on_outside_project(self, tmp_path: Path):
-        proj = tmp_path / "proj"
-        proj.mkdir()
-        outside = tmp_path / "other" / "Foo.lean"
-        outside.parent.mkdir()
-        outside.touch()
-        try:
-            make_axiom_check(outside, proj, "bar")
-            assert False, "Should have raised"
-        except ValueError:
-            pass
-
-    def test_does_not_remove_other_verify_temp_files(self, tmp_path: Path):
-        proj = tmp_path / "proj"
-        proj.mkdir()
-        src = proj / "Foo.lean"
-        src.write_text("theorem bar : True := trivial\n")
-        _, first_tmp = make_axiom_check(src, proj, "bar")
-        _, second_tmp = make_axiom_check(src, proj, "bar")
-        assert first_tmp.exists()
-        assert second_tmp.exists()
-
-
 class TestScanWarnings:
     @pytest.mark.skipif(not _has_rg, reason="ripgrep not installed")
     def test_finds_patterns(self, tmp_path: Path):


### PR DESCRIPTION
Issue: again I was seeing "axioms []", this time for lean_verify. The issue is that lean_verify uses the oleans, which sometimes are not updated, you would have to run lake build.

So fix appends `#print axioms ...` to the source file via LSP, reads diagnostics from the appended region, then restores original content. No olean files needed.

My previous PR was also about "axioms: []", it was merged, but this is different! :)