### PR TITLE
[feat] Semantic naming layer: tools that resolve by declaration name

### DIFF
--- a/src/lean_lsp_mcp/instructions.py
+++ b/src/lean_lsp_mcp/instructions.py
@@ -16,6 +16,14 @@ INSTRUCTIONS = """## General Rules
 - **lean_build**: Rebuild + restart LSP. Only if needed (new imports). SLOW!
 - **lean_profile_proof**: Profile a theorem for performance. Shows tactic hotspots. SLOW!
 
+## Name-Based Tools (no file path needed)
+- **lean_type**: Type signature by declaration name. e.g. `lean_type("IsNash")`
+- **lean_definition**: Source code by declaration name. Includes line range.
+- **lean_check_definition**: Diagnostics for a declaration by name.
+- **lean_goal_at**: Goal state by theorem name + tactic index. `tactic_index=0` first, `-1` last.
+
+These resolve names via lean_local_search + LSP. Use lean_local_search first if unsure of the exact name.
+
 ## Search Tools (rate limited)
 - **lean_leansearch** (3/30s): Natural language -> mathlib
 - **lean_loogle** (3/30s): Type pattern -> mathlib

--- a/src/lean_lsp_mcp/models.py
+++ b/src/lean_lsp_mcp/models.py
@@ -132,6 +132,27 @@ class DeclarationInfo(BaseModel):
     content: str = Field(description="File content")
 
 
+class TypeInfo(BaseModel):
+    """Type signature of a declaration resolved by name."""
+
+    name: str = Field(description="Fully qualified name")
+    type: str = Field(description="Type signature")
+    kind: str = Field(description="Declaration kind (theorem, def, class, etc.)")
+    file: str = Field(description="Relative file path")
+    line: int = Field(description="Start line (1-indexed)")
+
+
+class DefinitionSource(BaseModel):
+    """Source code of a declaration resolved by name."""
+
+    name: str = Field(description="Fully qualified name")
+    kind: str = Field(description="Declaration kind (theorem, def, class, etc.)")
+    file: str = Field(description="Relative file path")
+    start_line: int = Field(description="Start line (1-indexed)")
+    end_line: int = Field(description="End line (1-indexed)")
+    source: str = Field(description="Full source code of the declaration")
+
+
 # Wrapper models for list-returning tools
 # FastMCP flattens bare lists into separate TextContent blocks, causing serialization issues.
 # Wrapping in a model ensures proper JSON serialization.

--- a/src/lean_lsp_mcp/resolve.py
+++ b/src/lean_lsp_mcp/resolve.py
@@ -135,9 +135,11 @@ async def resolve_name(ctx: Context, name: str) -> ResolvedName:
     client: LeanLSPClient = lifespan.client
 
     # Step 6: Get declaration range using LSP document symbols
-    # Document symbols use the short name (part after last dot)
+    # Try short name first (namespace blocks), then full name (dotted declarations)
     short_name = full_name.rsplit(".", 1)[-1]
     decl_range = get_declaration_range(client, rel_path, short_name)
+    if decl_range is None and short_name != full_name:
+        decl_range = get_declaration_range(client, rel_path, full_name)
     if decl_range is None:
         raise LeanToolError(
             f"Declaration '{full_name}' found by search in '{rel_file}' "

--- a/src/lean_lsp_mcp/resolve.py
+++ b/src/lean_lsp_mcp/resolve.py
@@ -1,0 +1,158 @@
+"""Resolve Lean declaration names to file locations using ripgrep + LSP."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from mcp.server.fastmcp import Context
+
+from lean_lsp_mcp.client_utils import setup_client_for_file
+from lean_lsp_mcp.search_utils import lean_local_search
+from lean_lsp_mcp.utils import LeanToolError, get_declaration_range
+
+if TYPE_CHECKING:
+    from leanclient import LeanLSPClient
+
+
+@dataclass
+class ResolvedName:
+    """Internal result of resolving a declaration name to a file location."""
+
+    client: LeanLSPClient
+    rel_path: str
+    abs_path: str
+    start_line: int  # 1-indexed
+    end_line: int  # 1-indexed
+    kind: str
+    full_name: str
+
+
+def _match_name(candidate_name: str, query: str) -> bool:
+    """Check if candidate_name matches query exactly (full or short name)."""
+    if candidate_name == query:
+        return True
+    # Match on last dotted component (short name)
+    short = candidate_name.rsplit(".", 1)[-1]
+    if short == query:
+        return True
+    # Also match if query is a suffix of the FQN (e.g. "Ns.foo" matches "A.Ns.foo")
+    if candidate_name.endswith("." + query):
+        return True
+    return False
+
+
+async def resolve_name(ctx: Context, name: str) -> ResolvedName:
+    """Resolve a declaration name to file + range.
+
+    Steps:
+      1. lean_local_search(name) → candidates
+      2. Filter for exact name match (case-sensitive)
+      3. If 0 matches → LeanToolError with suggestion
+      4. If >1 matches → prefer project file over .lake/packages, error if still ambiguous
+      5. setup_client_for_file(ctx, abs_path) → (client, rel_path)
+      6. get_declaration_range(client, rel_path, short_name) → (start_line, end_line)
+      7. Return ResolvedName
+    """
+    name = name.strip()
+    if not name:
+        raise LeanToolError("Name must not be empty.")
+
+    lifespan = ctx.request_context.lifespan_context
+    project_root = lifespan.lean_project_path
+    if project_root is None:
+        raise LeanToolError(
+            "Lean project path not set. Call a file-based tool first, "
+            "or pass a file_path to any lean_ tool to initialize the project."
+        )
+
+    # Step 1: Search with ripgrep
+    # Use the short name (after last dot) as the ripgrep query for better recall
+    search_query = name.rsplit(".", 1)[-1]
+    raw_results = await asyncio.to_thread(
+        lean_local_search,
+        query=search_query,
+        limit=64,
+        project_root=project_root,
+    )
+
+    if not raw_results:
+        raise LeanToolError(
+            f"Declaration '{name}' not found. "
+            f"Use lean_local_search to discover available declarations."
+        )
+
+    # Step 2: Filter for exact match
+    matches = [r for r in raw_results if _match_name(r["name"], name)]
+
+    if not matches:
+        # Show top candidates from the search
+        top = raw_results[:5]
+        candidates = ", ".join(r["name"] for r in top)
+        raise LeanToolError(
+            f"No exact match for '{name}'. "
+            f"Closest candidates: {candidates}. "
+            f"Use lean_local_search for broader search."
+        )
+
+    # Step 3: Disambiguate
+    if len(matches) > 1:
+        # Prefer project files over .lake/packages
+        project_matches = [
+            m for m in matches if not m["file"].startswith(".lake/packages/")
+        ]
+        if len(project_matches) == 1:
+            matches = project_matches
+        elif len(project_matches) > 1:
+            matches = project_matches
+            # If still ambiguous but user gave FQN, try exact FQN match
+            fqn_matches = [m for m in matches if m["name"] == name]
+            if len(fqn_matches) >= 1:
+                matches = fqn_matches[:1]
+
+    if len(matches) > 1:
+        candidates = ", ".join(f"{m['name']} ({m['file']})" for m in matches)
+        raise LeanToolError(
+            f"Ambiguous name '{name}' matches multiple declarations: {candidates}. "
+            f"Use the fully qualified name to disambiguate."
+        )
+
+    match = matches[0]
+    full_name = match["name"]
+    kind = match["kind"]
+    rel_file = match["file"]
+
+    # Step 5: Setup client
+    abs_path = str((project_root / rel_file).resolve())
+    rel_path = setup_client_for_file(ctx, abs_path)
+    if not rel_path:
+        raise LeanToolError(
+            f"Unable to start LSP server for file '{rel_file}'."
+        )
+
+    client: LeanLSPClient = lifespan.client
+
+    # Step 6: Get declaration range using LSP document symbols
+    # Document symbols use the short name (part after last dot)
+    short_name = full_name.rsplit(".", 1)[-1]
+    decl_range = get_declaration_range(client, rel_path, short_name)
+    if decl_range is None:
+        raise LeanToolError(
+            f"Declaration '{full_name}' found by search in '{rel_file}' "
+            f"but LSP document symbols could not locate it. "
+            f"The file may need to be rebuilt (try lean_build)."
+        )
+
+    start_line, end_line = decl_range
+
+    return ResolvedName(
+        client=client,
+        rel_path=rel_path,
+        abs_path=abs_path,
+        start_line=start_line,
+        end_line=end_line,
+        kind=kind,
+        full_name=full_name,
+    )

--- a/src/lean_lsp_mcp/resolve.py
+++ b/src/lean_lsp_mcp/resolve.py
@@ -31,15 +31,16 @@ class ResolvedName:
 
 
 def _match_name(candidate_name: str, query: str) -> bool:
-    """Check if candidate_name matches query exactly (full or short name)."""
+    """Check if candidate_name matches query (full, short, or qualified name)."""
     if candidate_name == query:
         return True
-    # Match on last dotted component (short name)
-    short = candidate_name.rsplit(".", 1)[-1]
-    if short == query:
+    # Match on last dotted component (short name) in either direction
+    short_candidate = candidate_name.rsplit(".", 1)[-1]
+    short_query = query.rsplit(".", 1)[-1]
+    if short_candidate == query or short_query == candidate_name:
         return True
-    # Also match if query is a suffix of the FQN (e.g. "Ns.foo" matches "A.Ns.foo")
-    if candidate_name.endswith("." + query):
+    # Suffix match: "Ns.foo" matches "A.Ns.foo" or vice versa
+    if candidate_name.endswith("." + query) or query.endswith("." + candidate_name):
         return True
     return False
 

--- a/src/lean_lsp_mcp/resolve.py
+++ b/src/lean_lsp_mcp/resolve.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from mcp.server.fastmcp import Context
@@ -129,9 +128,7 @@ async def resolve_name(ctx: Context, name: str) -> ResolvedName:
     abs_path = str((project_root / rel_file).resolve())
     rel_path = setup_client_for_file(ctx, abs_path)
     if not rel_path:
-        raise LeanToolError(
-            f"Unable to start LSP server for file '{rel_file}'."
-        )
+        raise LeanToolError(f"Unable to start LSP server for file '{rel_file}'.")
 
     client: LeanLSPClient = lifespan.client
 

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -1767,7 +1767,9 @@ async def type_by_name(
     ctx: Context,
     name: Annotated[
         str,
-        Field(description="Declaration name (fully qualified or short, e.g. 'IsNash' or 'NFGame.IsNash')"),
+        Field(
+            description="Declaration name (fully qualified or short, e.g. 'IsNash' or 'NFGame.IsNash')"
+        ),
     ],
 ) -> TypeInfo:
     """Get the type signature of a declaration by name. Resolves name → file+position → hover."""
@@ -1778,7 +1780,9 @@ async def type_by_name(
 
     # Find the short name token on the start line to get the hover column
     short_name = resolved.full_name.rsplit(".", 1)[-1]
-    start_line_text = lines[resolved.start_line - 1] if resolved.start_line <= len(lines) else ""
+    start_line_text = (
+        lines[resolved.start_line - 1] if resolved.start_line <= len(lines) else ""
+    )
     col = start_line_text.find(short_name)
     if col < 0:
         col = 0  # Fallback to start of line
@@ -1917,7 +1921,7 @@ async def goal_at(
         # Also handle `by` followed by content on same line won't typically be multi-tactic
         if " by" in line and not line.strip().startswith("--"):
             # Check it's actually the proof `by`, not part of an identifier
-            if re.search(r'\bby\s*$', line):
+            if re.search(r"\bby\s*$", line):
                 by_offset = i
                 break
 
@@ -1951,12 +1955,10 @@ async def goal_at(
             f"(theorem has {len(tactic_lines)} tactic lines)."
         )
     abs_line_0, tactic_text = tactic_lines[tactic_index]
-    line_1indexed = abs_line_0 + 1
+    abs_line_0 + 1
 
     # Get goal at the start of the tactic (first non-space column)
-    col_start = next(
-        (i for i, c in enumerate(tactic_text) if not c.isspace()), 0
-    )
+    col_start = next((i for i, c in enumerate(tactic_text) if not c.isspace()), 0)
     col_end = len(tactic_text)
 
     goal_before = client.get_goal(resolved.rel_path, abs_line_0, col_start)

--- a/src/lean_lsp_mcp/utils.py
+++ b/src/lean_lsp_mcp/utils.py
@@ -333,6 +333,10 @@ def filter_diagnostics_by_position(
 def search_symbols(symbols: List[Dict], target_name: str) -> Dict | None:
     """Recursively search through symbols and their children.
 
+    Matches exact name, or suffix after a dot.  For example, target
+    ``"IsNash"`` matches symbol ``"NFGame.IsNash"`` (declaration without
+    a namespace block).
+
     Args:
         symbols: List of LSP document symbols
         target_name: Name of the symbol to find (case-sensitive)
@@ -341,7 +345,8 @@ def search_symbols(symbols: List[Dict], target_name: str) -> Dict | None:
         The matching symbol dict, or None if not found
     """
     for symbol in symbols:
-        if symbol.get("name") == target_name:
+        sym_name = symbol.get("name", "")
+        if sym_name == target_name or sym_name.endswith("." + target_name):
             return symbol
         # Search nested declarations (children)
         children = symbol.get("children", [])

--- a/tests/test_semantic_tools.py
+++ b/tests/test_semantic_tools.py
@@ -1,0 +1,159 @@
+"""Integration tests for the semantic naming tools (lean_type, lean_definition, etc.)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import AsyncContextManager
+
+import orjson
+import pytest
+
+from tests.helpers.mcp_client import MCPClient, result_json, result_text
+
+
+@pytest.fixture()
+def semantic_file(test_project_path: Path) -> Path:
+    """Write a test file with known declarations for semantic tool testing."""
+    path = test_project_path / "SemanticTest.lean"
+    content = "\n".join(
+        [
+            "import Mathlib",
+            "",
+            "def sampleDef : Nat := 42",
+            "",
+            "theorem sampleThm : 1 + 1 = 2 := by",
+            "  norm_num",
+            "",
+            "def SemanticNs.namespacedDef : Nat := 7",
+            "",
+        ]
+    )
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+@pytest.mark.asyncio
+async def test_lean_type(
+    mcp_client_factory: Callable[[], AsyncContextManager[MCPClient]],
+    semantic_file: Path,
+) -> None:
+    """lean_type should return the type signature of a declaration."""
+    async with mcp_client_factory() as client:
+        # First call a file-based tool to set the project path
+        await client.call_tool(
+            "lean_diagnostic_messages",
+            {"file_path": str(semantic_file)},
+        )
+
+        result = await client.call_tool(
+            "lean_type",
+            {"name": "sampleDef"},
+        )
+        text = result_text(result)
+        assert "sampleDef" in text
+        assert "Nat" in text or "ℕ" in text
+
+
+@pytest.mark.asyncio
+async def test_lean_definition(
+    mcp_client_factory: Callable[[], AsyncContextManager[MCPClient]],
+    semantic_file: Path,
+) -> None:
+    """lean_definition should return the source code of a declaration."""
+    async with mcp_client_factory() as client:
+        await client.call_tool(
+            "lean_diagnostic_messages",
+            {"file_path": str(semantic_file)},
+        )
+
+        result = await client.call_tool(
+            "lean_definition",
+            {"name": "sampleDef"},
+        )
+        text = result_text(result)
+        assert "42" in text
+        assert "sampleDef" in text
+
+
+@pytest.mark.asyncio
+async def test_lean_check_definition(
+    mcp_client_factory: Callable[[], AsyncContextManager[MCPClient]],
+    semantic_file: Path,
+) -> None:
+    """lean_check_definition should return diagnostics for a declaration."""
+    async with mcp_client_factory() as client:
+        await client.call_tool(
+            "lean_diagnostic_messages",
+            {"file_path": str(semantic_file)},
+        )
+
+        result = await client.call_tool(
+            "lean_check_definition",
+            {"name": "sampleDef"},
+        )
+        text = result_text(result)
+        # sampleDef should have no errors
+        assert "success" in text.lower() or "true" in text.lower() or '"items": []' in text
+
+
+@pytest.mark.asyncio
+async def test_lean_goal_at(
+    mcp_client_factory: Callable[[], AsyncContextManager[MCPClient]],
+    semantic_file: Path,
+) -> None:
+    """lean_goal_at should return goal state at a tactic position."""
+    async with mcp_client_factory() as client:
+        await client.call_tool(
+            "lean_diagnostic_messages",
+            {"file_path": str(semantic_file)},
+        )
+
+        result = await client.call_tool(
+            "lean_goal_at",
+            {"name": "sampleThm", "tactic_index": 0},
+        )
+        text = result_text(result)
+        # At the norm_num tactic, the goal should mention 1 + 1 = 2
+        assert "norm_num" in text or "1" in text
+
+
+@pytest.mark.asyncio
+async def test_lean_type_fqn(
+    mcp_client_factory: Callable[[], AsyncContextManager[MCPClient]],
+    semantic_file: Path,
+) -> None:
+    """lean_type should work with fully qualified names."""
+    async with mcp_client_factory() as client:
+        await client.call_tool(
+            "lean_diagnostic_messages",
+            {"file_path": str(semantic_file)},
+        )
+
+        result = await client.call_tool(
+            "lean_type",
+            {"name": "SemanticNs.namespacedDef"},
+        )
+        text = result_text(result)
+        assert "Nat" in text or "ℕ" in text
+
+
+@pytest.mark.asyncio
+async def test_lean_type_not_found(
+    mcp_client_factory: Callable[[], AsyncContextManager[MCPClient]],
+    semantic_file: Path,
+) -> None:
+    """lean_type should return error for nonexistent declarations."""
+    async with mcp_client_factory() as client:
+        await client.call_tool(
+            "lean_diagnostic_messages",
+            {"file_path": str(semantic_file)},
+        )
+
+        result = await client.call_tool(
+            "lean_type",
+            {"name": "totallyNonexistentDecl_xyz"},
+            expect_error=True,
+        )
+        text = result_text(result)
+        assert "not found" in text.lower()

--- a/tests/test_semantic_tools.py
+++ b/tests/test_semantic_tools.py
@@ -6,10 +6,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import AsyncContextManager
 
-import orjson
 import pytest
 
-from tests.helpers.mcp_client import MCPClient, result_json, result_text
+from tests.helpers.mcp_client import MCPClient, result_text
 
 
 @pytest.fixture()
@@ -94,7 +93,9 @@ async def test_lean_check_definition(
         )
         text = result_text(result)
         # sampleDef should have no errors
-        assert "success" in text.lower() or "true" in text.lower() or '"items": []' in text
+        assert (
+            "success" in text.lower() or "true" in text.lower() or '"items": []' in text
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_resolve.py
+++ b/tests/unit/test_resolve.py
@@ -1,0 +1,255 @@
+"""Unit tests for the resolve_name helper."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from lean_lsp_mcp.resolve import _match_name, resolve_name
+from lean_lsp_mcp.utils import LeanToolError
+
+
+# ---------------------------------------------------------------------------
+# _match_name pure logic
+# ---------------------------------------------------------------------------
+
+
+class TestMatchName:
+    def test_exact_full_name(self):
+        assert _match_name("NFGame.IsNash", "NFGame.IsNash") is True
+
+    def test_exact_short_name(self):
+        assert _match_name("NFGame.IsNash", "IsNash") is True
+
+    def test_suffix_match(self):
+        assert _match_name("A.B.IsNash", "B.IsNash") is True
+
+    def test_no_match(self):
+        assert _match_name("NFGame.IsNash", "NotNash") is False
+
+    def test_partial_short_no_match(self):
+        assert _match_name("NFGame.IsNash", "Nash") is False
+
+    def test_case_sensitive(self):
+        assert _match_name("NFGame.IsNash", "isnash") is False
+
+    def test_single_component_name(self):
+        assert _match_name("sampleValue", "sampleValue") is True
+
+    def test_short_matches_single_component(self):
+        # "sampleValue" has no dot, so short = "sampleValue"
+        assert _match_name("sampleValue", "sampleValue") is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_name with mocked dependencies
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeLifespan:
+    lean_project_path: Path | None = None
+    client: Any = None
+
+
+def _make_ctx(project_path: Path | None = None, client: Any = None) -> MagicMock:
+    """Create a minimal mock Context with lifespan."""
+    ctx = MagicMock()
+    lifespan = FakeLifespan(lean_project_path=project_path, client=client)
+    ctx.request_context.lifespan_context = lifespan
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_resolve_empty_name():
+    ctx = _make_ctx(project_path=Path("/proj"))
+    with pytest.raises(LeanToolError, match="Name must not be empty"):
+        await resolve_name(ctx, "")
+
+
+@pytest.mark.asyncio
+async def test_resolve_no_project_path():
+    ctx = _make_ctx(project_path=None)
+    with pytest.raises(LeanToolError, match="project path not set"):
+        await resolve_name(ctx, "foo")
+
+
+@pytest.mark.asyncio
+async def test_resolve_not_found(monkeypatch):
+    ctx = _make_ctx(project_path=Path("/proj"))
+
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.lean_local_search",
+        lambda query, limit, project_root: [],
+    )
+
+    with pytest.raises(LeanToolError, match="not found"):
+        await resolve_name(ctx, "NonexistentDecl")
+
+
+@pytest.mark.asyncio
+async def test_resolve_no_exact_match(monkeypatch):
+    ctx = _make_ctx(project_path=Path("/proj"))
+
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.lean_local_search",
+        lambda query, limit, project_root: [
+            {"name": "fooBar", "kind": "def", "file": "A.lean"},
+            {"name": "fooBaz", "kind": "def", "file": "B.lean"},
+        ],
+    )
+
+    with pytest.raises(LeanToolError, match="No exact match"):
+        await resolve_name(ctx, "foo")
+
+
+@pytest.mark.asyncio
+async def test_resolve_exact_fqn(monkeypatch):
+    mock_client = MagicMock()
+    ctx = _make_ctx(project_path=Path("/proj"), client=mock_client)
+
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.lean_local_search",
+        lambda query, limit, project_root: [
+            {"name": "Ns.myDef", "kind": "def", "file": "Ns.lean"},
+        ],
+    )
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.setup_client_for_file",
+        lambda c, path: "Ns.lean",
+    )
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.get_declaration_range",
+        lambda client, rel, name: (5, 10),
+    )
+
+    result = await resolve_name(ctx, "Ns.myDef")
+
+    assert result.full_name == "Ns.myDef"
+    assert result.kind == "def"
+    assert result.rel_path == "Ns.lean"
+    assert result.start_line == 5
+    assert result.end_line == 10
+
+
+@pytest.mark.asyncio
+async def test_resolve_short_name_unique(monkeypatch):
+    mock_client = MagicMock()
+    ctx = _make_ctx(project_path=Path("/proj"), client=mock_client)
+
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.lean_local_search",
+        lambda query, limit, project_root: [
+            {"name": "Ns.myDef", "kind": "def", "file": "Ns.lean"},
+        ],
+    )
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.setup_client_for_file",
+        lambda c, path: "Ns.lean",
+    )
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.get_declaration_range",
+        lambda client, rel, name: (5, 10),
+    )
+
+    result = await resolve_name(ctx, "myDef")
+
+    assert result.full_name == "Ns.myDef"
+    assert result.start_line == 5
+
+
+@pytest.mark.asyncio
+async def test_resolve_ambiguous_short_name(monkeypatch):
+    ctx = _make_ctx(project_path=Path("/proj"))
+
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.lean_local_search",
+        lambda query, limit, project_root: [
+            {"name": "A.myDef", "kind": "def", "file": "A.lean"},
+            {"name": "B.myDef", "kind": "def", "file": "B.lean"},
+        ],
+    )
+
+    with pytest.raises(LeanToolError, match="Ambiguous"):
+        await resolve_name(ctx, "myDef")
+
+
+@pytest.mark.asyncio
+async def test_resolve_prefers_project_over_lake(monkeypatch):
+    mock_client = MagicMock()
+    ctx = _make_ctx(project_path=Path("/proj"), client=mock_client)
+
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.lean_local_search",
+        lambda query, limit, project_root: [
+            {"name": "myDef", "kind": "def", "file": ".lake/packages/lib/Lib.lean"},
+            {"name": "myDef", "kind": "def", "file": "MyModule.lean"},
+        ],
+    )
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.setup_client_for_file",
+        lambda c, path: "MyModule.lean",
+    )
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.get_declaration_range",
+        lambda client, rel, name: (1, 3),
+    )
+
+    result = await resolve_name(ctx, "myDef")
+
+    assert result.rel_path == "MyModule.lean"
+
+
+@pytest.mark.asyncio
+async def test_resolve_fqn_disambiguates(monkeypatch):
+    mock_client = MagicMock()
+    ctx = _make_ctx(project_path=Path("/proj"), client=mock_client)
+
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.lean_local_search",
+        lambda query, limit, project_root: [
+            {"name": "A.myDef", "kind": "def", "file": "A.lean"},
+            {"name": "B.myDef", "kind": "def", "file": "B.lean"},
+        ],
+    )
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.setup_client_for_file",
+        lambda c, path: "A.lean",
+    )
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.get_declaration_range",
+        lambda client, rel, name: (1, 5),
+    )
+
+    result = await resolve_name(ctx, "A.myDef")
+
+    assert result.full_name == "A.myDef"
+    assert result.rel_path == "A.lean"
+
+
+@pytest.mark.asyncio
+async def test_resolve_lsp_range_not_found(monkeypatch):
+    mock_client = MagicMock()
+    ctx = _make_ctx(project_path=Path("/proj"), client=mock_client)
+
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.lean_local_search",
+        lambda query, limit, project_root: [
+            {"name": "myDef", "kind": "def", "file": "A.lean"},
+        ],
+    )
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.setup_client_for_file",
+        lambda c, path: "A.lean",
+    )
+    monkeypatch.setattr(
+        "lean_lsp_mcp.resolve.get_declaration_range",
+        lambda client, rel, name: None,
+    )
+
+    with pytest.raises(LeanToolError, match="could not locate"):
+        await resolve_name(ctx, "myDef")


### PR DESCRIPTION
Add 4 new MCP tools that accept Lean declaration names instead of file+line coordinates:

- lean_type(name) — type signature via name resolution + hover
- lean_definition(name) — full source code of a declaration
- lean_check_definition(name) — scoped diagnostics for a declaration
- lean_goal_at(name, tactic_index) — goal state at a tactic position

Resolution flow: name → ripgrep search → file → LSP document_symbols → range → LSP operation. No persistent index needed.

New files: resolve.py (core resolver), test_resolve.py (18 unit tests), test_semantic_tools.py (integration tests).
Updated: models.py (TypeInfo, DefinitionSource), instructions.py, server.py.