### PR TITLE
pipe setup subprocess stdio to fix #181

### DIFF
--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -589,6 +589,27 @@ async def _run_build(
         active_proc = proc
         return proc
 
+    async def _consume_build_output(proc: asyncio.subprocess.Process) -> None:
+        while line := await proc.stdout.readline():
+            line_str = line.decode("utf-8", errors="replace").rstrip()
+
+            if line_str.startswith("trace:") or "LEAN_PATH=" in line_str:
+                continue
+
+            log_lines.append(line_str)
+            if "error" in line_str.lower():
+                errors.append(line_str)
+
+            if m := re.search(
+                r"\[(\d+)/(\d+)\]\s*(.+?)(?:\s+\(\d+\.?\d*[ms]+\))?$", line_str
+            ):
+                await _safe_report_progress(
+                    ctx,
+                    progress=int(m.group(1)),
+                    total=int(m.group(2)),
+                    message=m.group(3) or "Building",
+                )
+
     try:
         clients_to_close: list[LeanLSPClient] = []
         with CLIENT_LOCK:
@@ -613,15 +634,29 @@ async def _run_build(
             await _safe_report_progress(
                 ctx, progress=1, total=16, message="Running `lake clean`"
             )
-            clean_proc = await _run_proc("lake", "clean", cwd=lean_project_path_obj)
+            clean_proc = await _run_proc(
+                "lake",
+                "clean",
+                cwd=lean_project_path_obj,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            await _consume_build_output(clean_proc)
             await clean_proc.wait()
 
         await _safe_report_progress(
             ctx, progress=2, total=16, message="Running `lake exe cache get`"
         )
         cache_proc = await _run_proc(
-            "lake", "exe", "cache", "get", cwd=lean_project_path_obj
+            "lake",
+            "exe",
+            "cache",
+            "get",
+            cwd=lean_project_path_obj,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
         )
+        await _consume_build_output(cache_proc)
         await cache_proc.wait()
 
         # Run build with progress reporting
@@ -634,27 +669,7 @@ async def _run_build(
             stderr=asyncio.subprocess.STDOUT,
         )
 
-        while line := await process.stdout.readline():
-            line_str = line.decode("utf-8", errors="replace").rstrip()
-
-            if line_str.startswith("trace:") or "LEAN_PATH=" in line_str:
-                continue
-
-            log_lines.append(line_str)
-            if "error" in line_str.lower():
-                errors.append(line_str)
-
-            # Parse progress: "[2/8] Building Foo (1.2s)" -> (2, 8, "Building Foo")
-            if m := re.search(
-                r"\[(\d+)/(\d+)\]\s*(.+?)(?:\s+\(\d+\.?\d*[ms]+\))?$", line_str
-            ):
-                await _safe_report_progress(
-                    ctx,
-                    progress=int(m.group(1)),
-                    total=int(m.group(2)),
-                    message=m.group(3) or "Building",
-                )
-
+        await _consume_build_output(process)
         await process.wait()
 
         if process.returncode != 0:

--- a/tests/unit/test_build_progress.py
+++ b/tests/unit/test_build_progress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -44,6 +45,7 @@ def build_mocks(tmp_path):
     # Simple process for cache (no stdout needed)
     cache_proc = MagicMock()
     cache_proc.wait = AsyncMock()
+    cache_proc.stdout.readline = AsyncMock(return_value=b"")
 
     # Build process with stdout
     build_proc = MagicMock()
@@ -159,6 +161,26 @@ async def test_reports_cache_progress(build_mocks, patch_build, tmp_path):
 
     # Should have reported cache fetch progress
     assert any("cache" in m.lower() for p, t, m in progress_calls)
+
+
+@pytest.mark.asyncio
+async def test_setup_subprocesses_pipe_output(build_mocks, patch_build, tmp_path):
+    """Setup subprocesses must not inherit stdio."""
+    project, ctx, cache_proc, build_proc = build_mocks
+    clean_proc = MagicMock()
+    clean_proc.wait = AsyncMock()
+    clean_proc.stdout.readline = AsyncMock(return_value=b"")
+    build_proc.stdout.readline = make_readline(b"Done\n")
+    patch_build.side_effect = [clean_proc, cache_proc, build_proc]
+
+    await lsp_build(ctx, lean_project_path=str(project), clean=True, output_lines=100)
+
+    clean_call = patch_build.await_args_list[0]
+    cache_call = patch_build.await_args_list[1]
+    assert clean_call.kwargs["stdout"] == asyncio.subprocess.PIPE
+    assert clean_call.kwargs["stderr"] == asyncio.subprocess.STDOUT
+    assert cache_call.kwargs["stdout"] == asyncio.subprocess.PIPE
+    assert cache_call.kwargs["stderr"] == asyncio.subprocess.STDOUT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #181.

Root cause: `lean_build` ran `lake clean` and `lake exe cache get` without redirecting stdout/stderr, so those setup subprocesses could write plaintext into the MCP stdio transport.

This pipes both setup steps through the same captured output path already used for `lake build --verbose`, and adds a focused regression test that asserts the setup subprocesses never inherit parent stdio.