### PR TITLE
docs: add tool_timeout_sec to Mistral Vibe setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ name = "lean-lsp"
 transport = "stdio"
 command = "uvx"
 args = ["lean-lsp-mcp"]
+tool_timeout_sec = 600
 ```
 If there are no existing MCP servers, you may have to remove `mcp_servers = []`.
 </details>


### PR DESCRIPTION
The default vibe tool timeout (60s) is too short for Lean operations like building Mathlib projects. This adds `tool_timeout_sec = 600` to the Mistral Vibe setup instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)