### PR TITLE
Optional structured output for lean_goal

### DIFF
--- a/src/lean_lsp_mcp/models.py
+++ b/src/lean_lsp_mcp/models.py
@@ -1,7 +1,7 @@
 """Pydantic models for MCP tool structured outputs."""
 
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -53,15 +53,32 @@ class DiagnosticMessage(BaseModel):
     column: int = Field(description="Column (1-indexed)")
 
 
+class GoalContextEntry(BaseModel):
+    name: str = Field(description="Local hypothesis or variable name")
+    type: str = Field(description="Lean type")
+
+
+class StructuredGoal(BaseModel):
+    context: List[GoalContextEntry] = Field(
+        default_factory=list, description="Local context entries"
+    )
+    goal: Optional[str] = Field(None, description="Target goal")
+    status: str = Field(description="Goal status: open, complete, or unknown")
+    pretty: str = Field(description="Original pretty-printed goal")
+
+
+GoalOutput = Union[str, StructuredGoal]
+
+
 class GoalState(BaseModel):
     line_context: str = Field(description="Source line where goals were queried")
-    goals: Optional[List[str]] = Field(
+    goals: Optional[List[GoalOutput]] = Field(
         None, description="Goal list at specified column position"
     )
-    goals_before: Optional[List[str]] = Field(
+    goals_before: Optional[List[GoalOutput]] = Field(
         None, description="Goals at line start (when column omitted)"
     )
-    goals_after: Optional[List[str]] = Field(
+    goals_after: Optional[List[GoalOutput]] = Field(
         None, description="Goals at line end (when column omitted)"
     )
 

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -13,7 +13,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Dict, List, Optional
+from typing import Annotated, Dict, List, Optional, Literal
 
 import certifi
 import orjson
@@ -925,6 +925,10 @@ def goal(
         Optional[int],
         Field(description="Column (1-indexed). Omit for before/after", ge=1),
     ] = None,
+    format: Annotated[
+        Literal["text", "structured"],
+        Field(description="Output format: 'text' (default) or 'structured'")
+    ] = "text", 
 ) -> GoalState:
     """Get proof goals at a position. MOST IMPORTANT tool - use often!
 
@@ -953,18 +957,93 @@ def goal(
         goal_start = _get_goal_response(client, rel_path, line - 1, column_start)
         check_lsp_response(goal_start, "get_goal", allow_none=True)
         goal_end = _get_goal_response(client, rel_path, line - 1, column_end)
+        goals_before = extract_goals_list(goal_start)
+        goals_after = extract_goals_list(goal_end)
+
+        if format == "structured":
+            goals_before = [_goal_to_structured(g) for g in goals_before]
+            goals_after = [_goal_to_structured(g) for g in goals_after]
+
         return GoalState(
             line_context=line_context,
-            goals_before=extract_goals_list(goal_start),
-            goals_after=extract_goals_list(goal_end),
+            goals_before=goals_before,
+            goals_after=goals_after,
         )
     else:
         goal_result = _get_goal_response(client, rel_path, line - 1, column - 1)
         check_lsp_response(goal_result, "get_goal", allow_none=True)
+        goals = extract_goals_list(goal_result)
+        if format == "structured":
+            goals = [_goal_to_structured(g) for g in goals]
         return GoalState(
-            line_context=line_context, goals=extract_goals_list(goal_result)
+            line_context=line_context,
+            goals=goals
         )
 
+def _goal_to_structured(goal_str: str) -> dict:
+    goal_str = (goal_str or "").strip()
+
+    # Case: no goals (proof finished)
+    if goal_str == "" or goal_str.lower() == "no goals":
+        return {
+            "context": [],
+            "goal": None,
+            "status": "complete",
+            "pretty": goal_str,
+        }
+
+    # Case: no turnstile (fallback)
+    if "⊢" not in goal_str:
+        return {
+            "context": [],
+            "goal": goal_str,
+            "status": "unknown",
+            "pretty": goal_str,
+        }
+
+    before, after = goal_str.split("⊢", 1)
+
+    context = []
+    lines = before.splitlines()
+
+    current_name = None
+    current_type_lines = []
+
+    def flush():
+        nonlocal current_name, current_type_lines
+        if current_name is not None:
+            context.append({
+                "name": current_name,
+                "type": " ".join(l.strip() for l in current_type_lines).strip()
+            })
+        current_name = None
+        current_type_lines = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        if not stripped:
+            continue
+
+        # New hypothesis line
+        if ":" in stripped and not line.startswith(" "):
+            flush()
+            name, typ = stripped.split(":", 1)
+            current_name = name.strip()
+            current_type_lines = [typ.strip()]
+        else:
+            # continuation of previous type
+            if current_name is not None:
+                current_type_lines.append(stripped)
+
+    flush()
+
+    return {
+        "context": context,
+        "goal": after.strip(),
+        "status": "open",
+        "pretty": goal_str,
+    }
 
 def _get_goal_response(
     client: LeanLSPClient, rel_path: str, line: int, column: int

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -13,7 +13,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Dict, List, Optional, Literal
+from typing import Annotated, Dict, List, Literal, Optional
 
 import certifi
 import orjson
@@ -83,6 +83,7 @@ from lean_lsp_mcp.models import (
     SourceWarning,
     StateSearchResult,
     StateSearchResults,
+    StructuredGoal,
     TermGoalState,
     VerifyResult,
 )
@@ -927,8 +928,8 @@ def goal(
     ] = None,
     format: Annotated[
         Literal["text", "structured"],
-        Field(description="Output format: 'text' (default) or 'structured'")
-    ] = "text", 
+        Field(description="Output format: 'text' (default) or 'structured'"),
+    ] = "text",
 ) -> GoalState:
     """Get proof goals at a position. MOST IMPORTANT tool - use often!
 
@@ -977,29 +978,30 @@ def goal(
             goals = [_goal_to_structured(g) for g in goals]
         return GoalState(
             line_context=line_context,
-            goals=goals
+            goals=goals,
         )
 
-def _goal_to_structured(goal_str: str) -> dict:
+
+def _goal_to_structured(goal_str: str) -> StructuredGoal:
     goal_str = (goal_str or "").strip()
 
     # Case: no goals (proof finished)
     if goal_str == "" or goal_str.lower() == "no goals":
-        return {
-            "context": [],
-            "goal": None,
-            "status": "complete",
-            "pretty": goal_str,
-        }
+        return StructuredGoal(
+            context=[],
+            goal=None,
+            status="complete",
+            pretty=goal_str,
+        )
 
     # Case: no turnstile (fallback)
     if "⊢" not in goal_str:
-        return {
-            "context": [],
-            "goal": goal_str,
-            "status": "unknown",
-            "pretty": goal_str,
-        }
+        return StructuredGoal(
+            context=[],
+            goal=goal_str,
+            status="unknown",
+            pretty=goal_str,
+        )
 
     before, after = goal_str.split("⊢", 1)
 
@@ -1012,10 +1014,14 @@ def _goal_to_structured(goal_str: str) -> dict:
     def flush():
         nonlocal current_name, current_type_lines
         if current_name is not None:
-            context.append({
-                "name": current_name,
-                "type": " ".join(l.strip() for l in current_type_lines).strip()
-            })
+            context.append(
+                {
+                    "name": current_name,
+                    "type": " ".join(
+                        line.strip() for line in current_type_lines
+                    ).strip(),
+                }
+            )
         current_name = None
         current_type_lines = []
 
@@ -1038,12 +1044,13 @@ def _goal_to_structured(goal_str: str) -> dict:
 
     flush()
 
-    return {
-        "context": context,
-        "goal": after.strip(),
-        "status": "open",
-        "pretty": goal_str,
-    }
+    return StructuredGoal(
+        context=context,
+        goal=after.strip(),
+        status="open",
+        pretty=goal_str,
+    )
+
 
 def _get_goal_response(
     client: LeanLSPClient, rel_path: str, line: int, column: int

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -908,6 +908,48 @@ def test_goal_retries_after_cold_file_timeout(monkeypatch: pytest.MonkeyPatch) -
     assert fake_client.diagnostic_calls == [("GoalSample.lean", 30.0)]
 
 
+def test_goal_structured_format_accepts_structured_goals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeClient:
+        def open_file(self, _path: str, force_reopen: bool = False, **_kw) -> None:
+            pass
+
+        def get_file_content(self, _path: str) -> str:
+            return "import Mathlib\n\ntheorem sample_goal (x : Nat) (h : x = 0) : x = 0 := by\n  exact h\n"
+
+        def get_goal(self, _path: str, _line: int, _column: int) -> dict:
+            return {"goals": ["x : Nat\nh : x = 0\n⊢ x = 0"]}
+
+    monkeypatch.setattr(
+        server, "setup_client_for_file", lambda _ctx, _path: "GoalSample.lean"
+    )
+
+    ctx = _make_ctx()
+    ctx.request_context.lifespan_context.client = FakeClient()
+
+    result = server.goal(
+        ctx,
+        file_path="/abs/GoalSample.lean",
+        line=4,
+        column=3,
+        format="structured",
+    )
+
+    assert result.goals is not None
+    structured_goal = result.goals[0]
+    assert not isinstance(structured_goal, str)
+    assert structured_goal.model_dump() == {
+        "context": [
+            {"name": "x", "type": "Nat"},
+            {"name": "h", "type": "x = 0"},
+        ],
+        "goal": "x = 0",
+        "status": "open",
+        "pretty": "x : Nat\nh : x = 0\n⊢ x = 0",
+    }
+
+
 def test_goal_returns_no_goals_without_retry(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeClient:
         def __init__(self) -> None:


### PR DESCRIPTION
Closes #186 

This extension adds a structured way to represent Lean goals without changing the existing LSP or tool interface.

It works by taking the goal as it is displayed by Lean and converting it into two parts:
(Γ,G), where Γ is the local context and G is the target.

The context Γ contains the variables and assumptions available at that point in the proof. Each entry has the form x:T, meaning a name and its type. These represent exactly what can be used to prove the goal.

Since Lean does not directly provide this structure through the LSP, the conversion is based on the displayed text. This means it is an approximation of the underlying proof state, but it works well for typical goal shapes, including multiline hypotheses and completed proofs.

The goal of this design is to keep changes minimal, make the tool easier to use for programs, and remain compatible with existing behavior, while allowing future improvements if the LSP provides more structured data.