### PR TITLE
feat(server): add lean_minimal_hypotheses tool

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -238,6 +238,42 @@ Check theorem soundness: returns axioms used + optional source pattern scan for 
 ```
 </details>
 
+#### lean_minimal_hypotheses
+
+For each explicit `(h : T)` hypothesis of a theorem, drop it and re-elaborate the file via the LSP. Reports which hypotheses are load-bearing and which are actually unused. For load-bearing hypotheses, the verdict includes a list of `breaks` — every new error caused by removing the binder, with line, column, and message — so you can see *where* in the proof the dropped hypothesis was used. Useful for "minimum hypotheses needed" / counterfactual reasoning when sharpening a result.
+
+Skips implicit `{x : α}` and instance `[inst : C]` binders. Does not rewrite the proof body — a body that names `h` will fail to elaborate without the binder, which is the truthful answer (load-bearing).
+
+Slow: each hypothesis triggers a full re-elaboration capped at `inactivity_timeout` (default 60 s). The original file content is restored before the tool returns.
+
+<details>
+<summary>Example output (one of two hypotheses unused)</summary>
+
+```json
+{
+  "theorem_name": "minhyp_one_unused",
+  "file": "MinimalHypothesesTest.lean",
+  "verdicts": [
+    {
+      "binder": "(h1 : 1 + 1 = 2)",
+      "status": "load-bearing",
+      "breaks": [
+        {"severity": "error", "message": "unknown identifier 'h1'", "line": 7, "column": 3}
+      ],
+      "detail": ""
+    },
+    {
+      "binder": "(h2 : 2 + 2 = 4)",
+      "status": "removable",
+      "breaks": [],
+      "detail": ""
+    }
+  ],
+  "skipped_implicit": 0
+}
+```
+</details>
+
 ### Local Search Tools
 
 #### lean_local_search

--- a/src/lean_lsp_mcp/minimal_hypotheses.py
+++ b/src/lean_lsp_mcp/minimal_hypotheses.py
@@ -1,0 +1,87 @@
+"""Minimal-hypothesis pruning: parse a theorem's binders, drop each
+explicit `(h : T)` in turn, and let the caller re-check via the LSP.
+
+Pure parsing utilities — no I/O, no LSP. Designed so that callers (server.py)
+can drive the LSP overlay loop without re-implementing the binder parser.
+"""
+
+from __future__ import annotations
+
+import re
+
+_DECL_RE = re.compile(r"\b(theorem|lemma|example|def)\s+([A-Za-z_][A-Za-z0-9_'.]*)")
+
+
+def _find_balanced_close(s: str, open_pos: int, open_ch: str, close_ch: str) -> int:
+    """Index of the matching close char, or -1 if unbalanced.
+    Counts opens and closes only; does not skip strings or comments."""
+    depth = 0
+    for i in range(open_pos, len(s)):
+        ch = s[i]
+        if ch == open_ch:
+            depth += 1
+        elif ch == close_ch:
+            depth -= 1
+            if depth == 0:
+                return i
+    return -1
+
+
+def find_theorem_binders(source: str, name: str) -> list[tuple[str, int, int]]:
+    """Find the binder list of a theorem/lemma/def.
+
+    Walks forward from the declaration name, consuming consecutive top-level
+    `(...)`, `{...}`, and `[...]` groups until it hits the type-introducing `:`
+    or end-of-binders. Returns `[(binder_text, start, end_exclusive), ...]` in
+    source order.
+
+    Note: doesn't strip Lean comments — assume well-formatted code. Matches the
+    *first* declaration in `source` whose name equals `name`; bare names should
+    be unique within a file or this will pick the wrong one.
+    """
+    pattern = re.compile(rf"\b(theorem|lemma|example|def)\s+{re.escape(name)}\b")
+    m = pattern.search(source)
+    if not m:
+        return []
+
+    pos = m.end()
+    binders: list[tuple[str, int, int]] = []
+    closers = {"(": ")", "{": "}", "[": "]"}
+    while pos < len(source):
+        while pos < len(source) and source[pos] in " \t\n\r":
+            pos += 1
+        if pos >= len(source):
+            break
+        ch = source[pos]
+        if ch in closers:
+            close = _find_balanced_close(source, pos, ch, closers[ch])
+            if close == -1:
+                break
+            binders.append((source[pos : close + 1], pos, close + 1))
+            pos = close + 1
+        else:
+            break
+    return binders
+
+
+def explicit_hypotheses(
+    binders: list[tuple[str, int, int]],
+) -> list[tuple[str, int, int]]:
+    """Filter a binder list to just `(h : T)` style explicit hypotheses.
+
+    Skips implicit `{x : α}` and instance `[inst : C]` binders — those are
+    inferable / always load-bearing in practice.
+    """
+    return [(b, s, e) for (b, s, e) in binders if b.startswith("(") and ":" in b]
+
+
+def drop_binder(source: str, start: int, end: int) -> str:
+    """Return `source` with the binder at [start, end) removed,
+    also absorbing one preceding space so two single-spaces don't collide."""
+    cut = start - 1 if start > 0 and source[start - 1] == " " else start
+    return source[:cut] + source[end:]
+
+
+def line_of_offset(source: str, offset: int) -> int:
+    """1-indexed line number of a character offset."""
+    return source.count("\n", 0, offset) + 1

--- a/src/lean_lsp_mcp/models.py
+++ b/src/lean_lsp_mcp/models.py
@@ -354,3 +354,45 @@ class VerifyResult(BaseModel):
         default_factory=list,
         description="Suspicious source patterns (if enabled)",
     )
+
+
+class HypothesisStatus(str, Enum):
+    load_bearing = "load-bearing"
+    removable = "removable"
+    error = "error"
+
+
+class HypothesisVerdict(BaseModel):
+    binder: str = Field(description="Lean source of the binder, e.g. '(h : P)'")
+    status: HypothesisStatus = Field(
+        description=(
+            "load-bearing: removing this binder caused new errors. "
+            "removable: the file still elaborated cleanly without it. "
+            "error: probing this binder failed (e.g. LSP timeout)."
+        )
+    )
+    breaks: List[DiagnosticMessage] = Field(
+        default_factory=list,
+        description=(
+            "New errors caused by removing this binder (empty when removable). "
+            "Each entry has line/column/message — useful for finding where in "
+            "the proof body the dropped hypothesis was used."
+        ),
+    )
+    detail: str = Field(
+        default="",
+        description="Free-text status detail (e.g. timeout reason)",
+    )
+
+
+class MinimalHypothesesResult(BaseModel):
+    theorem_name: str = Field(description="Theorem analyzed")
+    file: str = Field(description="Relative file path")
+    verdicts: List[HypothesisVerdict] = Field(
+        default_factory=list,
+        description="One verdict per explicit (h : T) binder, in source order",
+    )
+    skipped_implicit: int = Field(
+        default=0,
+        description="Count of implicit {x : α} / instance [inst] binders not probed",
+    )

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -71,6 +71,7 @@ from lean_lsp_mcp.models import (
     LocalSearchResults,
     LoogleResult,
     LoogleResults,
+    MinimalHypothesesResult,
     MultiAttemptResult,
     PremiseResult,
     PremiseResults,
@@ -80,6 +81,8 @@ from lean_lsp_mcp.models import (
     RunResult,
     WidgetSourceResult,
     WidgetsResult,
+    HypothesisStatus,
+    HypothesisVerdict,
     SourceWarning,
     StateSearchResult,
     StateSearchResults,
@@ -1789,6 +1792,197 @@ def verify_theorem(
             ]
 
     return VerifyResult(axioms=axioms, warnings=w)
+
+
+@mcp.tool(
+    "lean_minimal_hypotheses",
+    annotations=ToolAnnotations(
+        title="Minimal Hypotheses",
+        readOnlyHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def minimal_hypotheses(
+    ctx: Context,
+    file_path: Annotated[str, Field(description="Absolute path to Lean file")],
+    theorem_name: Annotated[
+        str,
+        Field(
+            description=(
+                "Theorem name. Either bare (e.g. `add_comm`) or fully qualified "
+                "(e.g. `Namespace.add_comm`); only the trailing segment is used "
+                "for source matching."
+            ),
+        ),
+    ],
+    inactivity_timeout: Annotated[
+        float,
+        Field(
+            description="Per-hypothesis LSP elaboration timeout (seconds)",
+            ge=5.0,
+            le=300.0,
+        ),
+    ] = 60.0,
+) -> MinimalHypothesesResult:
+    """For each explicit `(h : T)` hypothesis of a theorem, drop it and re-elaborate
+    the file via the LSP. Reports which hypotheses are load-bearing and which are
+    actually unused. Skips implicit `{x : α}` and instance `[inst : C]` binders
+    (those are usually inferable / always load-bearing). Does not rewrite the proof
+    body — a body that names `h` will fail to elaborate without the binder, which
+    is the truthful answer (load-bearing).
+
+    Slow: each hypothesis triggers a re-elaboration capped at `inactivity_timeout`.
+    The original file content is restored before the tool returns."""
+    from lean_lsp_mcp.minimal_hypotheses import (
+        drop_binder,
+        explicit_hypotheses,
+        find_theorem_binders,
+    )
+
+    theorem_name = _validate_theorem_name(theorem_name)
+    rel_path = setup_client_for_file(ctx, file_path)
+    if not rel_path:
+        _raise_invalid_path(file_path)
+
+    client: LeanLSPClient = ctx.request_context.lifespan_context.client
+    client.open_file(rel_path)
+    try:
+        original_content = client.get_file_content(rel_path)
+    except Exception:
+        try:
+            policy = get_path_policy(ctx)
+            abs_path = policy.validate_path(resolve_file_path(ctx, file_path))
+        except (FileNotFoundError, ValueError) as exc:
+            raise LeanToolError(str(exc)) from exc
+        original_content = get_file_contents(abs_path)
+
+    if original_content is None:
+        raise LeanToolError(f"Could not read content for {rel_path}")
+
+    bare_name = theorem_name.split(".")[-1]
+    binders = find_theorem_binders(original_content, bare_name)
+    if not binders:
+        raise LeanToolError(
+            f"Could not find theorem '{theorem_name}' in {rel_path}, "
+            "or it has no binders before its type."
+        )
+    explicit = explicit_hypotheses(binders)
+    skipped = len(binders) - len(explicit)
+
+    if not explicit:
+        return MinimalHypothesesResult(
+            theorem_name=theorem_name,
+            file=rel_path,
+            verdicts=[],
+            skipped_implicit=skipped,
+        )
+
+    def _error_key(diag: Dict) -> tuple[int, int, str]:
+        """Stable identifier for a single LSP diagnostic — used to filter the
+        set of *new* errors against the pre-modification baseline. Line and
+        column may shift slightly if a multi-line binder is removed, but most
+        binders are single-line so (line, column, message[:120]) is stable
+        in practice.
+        """
+        r = diag.get("fullRange", diag.get("range")) or {}
+        start = r.get("start", {})
+        return (
+            int(start.get("line", -1)),
+            int(start.get("character", -1)),
+            str(diag.get("message", ""))[:120],
+        )
+
+    baseline = client.get_diagnostics(rel_path, inactivity_timeout=inactivity_timeout)
+    check_lsp_response(baseline, "get_diagnostics")
+    baseline_keys = {
+        _error_key(d) for d in list(baseline or []) if d.get("severity") == 1
+    }
+
+    verdicts: list[HypothesisVerdict] = []
+    try:
+        for binder, start, end in explicit:
+            modified = drop_binder(original_content, start, end)
+            try:
+                client.update_file_content(rel_path, modified)
+            except Exception as exc:
+                verdicts.append(
+                    HypothesisVerdict(
+                        binder=binder.strip(),
+                        status=HypothesisStatus.error,
+                        detail=f"update_file_content failed: {exc}",
+                    )
+                )
+                continue
+
+            diag = client.get_diagnostics(
+                rel_path, inactivity_timeout=inactivity_timeout
+            )
+            try:
+                check_lsp_response(diag, "get_diagnostics")
+            except Exception as exc:
+                verdicts.append(
+                    HypothesisVerdict(
+                        binder=binder.strip(),
+                        status=HypothesisStatus.error,
+                        detail=str(exc)[:200],
+                    )
+                )
+                continue
+
+            if getattr(diag, "timed_out", False):
+                verdicts.append(
+                    HypothesisVerdict(
+                        binder=binder.strip(),
+                        status=HypothesisStatus.error,
+                        detail=f"LSP elaboration timed out after {inactivity_timeout}s",
+                    )
+                )
+                continue
+
+            new_errors = [
+                d
+                for d in list(diag or [])
+                if d.get("severity") == 1 and _error_key(d) not in baseline_keys
+            ]
+            if new_errors:
+                breaks = _to_diagnostic_messages(new_errors)
+                verdicts.append(
+                    HypothesisVerdict(
+                        binder=binder.strip(),
+                        status=HypothesisStatus.load_bearing,
+                        breaks=breaks,
+                    )
+                )
+            else:
+                verdicts.append(
+                    HypothesisVerdict(
+                        binder=binder.strip(),
+                        status=HypothesisStatus.removable,
+                    )
+                )
+    finally:
+        try:
+            client.update_file_content(rel_path, original_content)
+        except Exception as exc:
+            logger.warning(
+                "Failed to restore `%s` after minimal_hypotheses: %s", rel_path, exc
+            )
+        try:
+            client.open_file(rel_path, force_reopen=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to force-reopen `%s` after minimal_hypotheses: %s",
+                rel_path,
+                exc,
+            )
+
+    return MinimalHypothesesResult(
+        theorem_name=theorem_name,
+        file=rel_path,
+        verdicts=verdicts,
+        skipped_implicit=skipped,
+    )
 
 
 class LocalSearchError(Exception):

--- a/tests/test_minimal_hypotheses.py
+++ b/tests/test_minimal_hypotheses.py
@@ -1,0 +1,128 @@
+"""Integration tests for lean_minimal_hypotheses tool."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import AsyncContextManager
+
+import pytest
+
+from tests.helpers.mcp_client import MCPClient, result_json
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+async def test_minimal_hypotheses_one_unused(
+    mcp_client_factory: Callable[[], AsyncContextManager[MCPClient]],
+    test_project_path: Path,
+) -> None:
+    """h1 is referenced in the body, h2 is not — so h2 is removable, h1 load-bearing.
+    The load-bearing verdict's `breaks` should pinpoint the body line that names h1."""
+    test_file = test_project_path / "MinimalHypothesesTest.lean"
+    async with mcp_client_factory() as client:
+        result = await client.call_tool(
+            "lean_minimal_hypotheses",
+            {
+                "file_path": str(test_file),
+                "theorem_name": "minhyp_one_unused",
+            },
+        )
+        data = result_json(result)
+        by_binder = {v["binder"]: v for v in data["verdicts"]}
+        assert by_binder["(h1 : 1 + 1 = 2)"]["status"] == "load-bearing"
+        assert by_binder["(h2 : 2 + 2 = 4)"]["status"] == "removable"
+
+        # Removing h1 must pinpoint the body line that names h1.
+        h1_breaks = by_binder["(h1 : 1 + 1 = 2)"]["breaks"]
+        assert h1_breaks, "expected `breaks` to enumerate the new errors"
+        assert any("h1" in b["message"] for b in h1_breaks), (
+            f"expected an error referencing h1, got: {h1_breaks}"
+        )
+        # Removing the unused h2 must produce no breaks.
+        assert by_binder["(h2 : 2 + 2 = 4)"]["breaks"] == []
+        assert data["skipped_implicit"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+async def test_minimal_hypotheses_both_used(
+    mcp_client_factory: Callable[[], AsyncContextManager[MCPClient]],
+    test_project_path: Path,
+) -> None:
+    test_file = test_project_path / "MinimalHypothesesTest.lean"
+    async with mcp_client_factory() as client:
+        result = await client.call_tool(
+            "lean_minimal_hypotheses",
+            {
+                "file_path": str(test_file),
+                "theorem_name": "minhyp_both_used",
+            },
+        )
+        data = result_json(result)
+        statuses = [v["status"] for v in data["verdicts"]]
+        assert statuses == ["load-bearing", "load-bearing"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+async def test_minimal_hypotheses_no_explicit(
+    mcp_client_factory: Callable[[], AsyncContextManager[MCPClient]],
+    test_project_path: Path,
+) -> None:
+    test_file = test_project_path / "MinimalHypothesesTest.lean"
+    async with mcp_client_factory() as client:
+        result = await client.call_tool(
+            "lean_minimal_hypotheses",
+            {
+                "file_path": str(test_file),
+                "theorem_name": "minhyp_no_hypotheses",
+            },
+        )
+        data = result_json(result)
+        assert data["verdicts"] == []
+        assert data["skipped_implicit"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+async def test_minimal_hypotheses_skips_implicit_and_instance(
+    mcp_client_factory: Callable[[], AsyncContextManager[MCPClient]],
+    test_project_path: Path,
+) -> None:
+    """`{α : Type}` and `[DecidableEq α]` are skipped — only h1/h2 are probed."""
+    test_file = test_project_path / "MinimalHypothesesTest.lean"
+    async with mcp_client_factory() as client:
+        result = await client.call_tool(
+            "lean_minimal_hypotheses",
+            {
+                "file_path": str(test_file),
+                "theorem_name": "minhyp_mixed_binders",
+            },
+        )
+        data = result_json(result)
+        verdicts = {v["binder"]: v["status"] for v in data["verdicts"]}
+        assert verdicts == {
+            "(h1 : 1 + 1 = 2)": "load-bearing",
+            "(h2 : 2 + 2 = 4)": "removable",
+        }
+        # {α : Type} and [DecidableEq α]
+        assert data["skipped_implicit"] == 2
+
+
+@pytest.mark.asyncio
+async def test_minimal_hypotheses_unknown_theorem(
+    mcp_client_factory: Callable[[], AsyncContextManager[MCPClient]],
+    test_project_path: Path,
+) -> None:
+    test_file = test_project_path / "MinimalHypothesesTest.lean"
+    async with mcp_client_factory() as client:
+        result = await client.call_tool(
+            "lean_minimal_hypotheses",
+            {
+                "file_path": str(test_file),
+                "theorem_name": "nonexistent_xyz",
+            },
+            expect_error=True,
+        )
+        assert result.isError

--- a/tests/test_project/MinimalHypothesesTest.lean
+++ b/tests/test_project/MinimalHypothesesTest.lean
@@ -1,0 +1,16 @@
+import Mathlib
+
+-- Both hypotheses are referenced in the body → both load-bearing.
+theorem minhyp_both_used (h1 : 1 + 1 = 2) (h2 : 2 + 2 = 4) : 1 + 1 = 2 ∧ 2 + 2 = 4 :=
+  ⟨h1, h2⟩
+
+-- The body never names h2 → h2 is removable.
+theorem minhyp_one_unused (h1 : 1 + 1 = 2) (h2 : 2 + 2 = 4) : 1 + 1 = 2 :=
+  h1
+
+-- No explicit (h : T) hypotheses.
+theorem minhyp_no_hypotheses : True := trivial
+
+-- Mix of explicit + implicit + instance binders. Body uses h1 only.
+theorem minhyp_mixed_binders {α : Type} [DecidableEq α] (h1 : 1 + 1 = 2) (h2 : 2 + 2 = 4) : 1 + 1 = 2 :=
+  h1

--- a/tests/unit/test_minimal_hypotheses.py
+++ b/tests/unit/test_minimal_hypotheses.py
@@ -1,0 +1,89 @@
+"""Unit tests for the minimal_hypotheses parser helpers."""
+
+from __future__ import annotations
+
+from lean_lsp_mcp.minimal_hypotheses import (
+    _find_balanced_close,
+    drop_binder,
+    explicit_hypotheses,
+    find_theorem_binders,
+    line_of_offset,
+)
+
+
+class TestFindBalancedClose:
+    def test_simple(self):
+        assert _find_balanced_close("(a)", 0, "(", ")") == 2
+
+    def test_nested(self):
+        assert _find_balanced_close("((x)y)", 0, "(", ")") == 5
+        assert _find_balanced_close("((x)y)", 1, "(", ")") == 3
+
+    def test_unbalanced_returns_negative(self):
+        assert _find_balanced_close("((x)", 0, "(", ")") == -1
+
+
+class TestFindTheoremBinders:
+    def test_returns_each_binder_in_order(self):
+        src = (
+            "theorem foo (h1 : P) (h2 : Q) {x : Nat} [DecidableEq α] : R := by\n"
+            "  exact h1\n"
+        )
+        texts = [b[0] for b in find_theorem_binders(src, "foo")]
+        assert texts == ["(h1 : P)", "(h2 : Q)", "{x : Nat}", "[DecidableEq α]"]
+
+    def test_handles_nested_parens_in_type(self):
+        src = "theorem foo (h : P → (Q ∧ R)) (k : S) : T := sorry\n"
+        texts = [b[0] for b in find_theorem_binders(src, "foo")]
+        assert texts == ["(h : P → (Q ∧ R))", "(k : S)"]
+
+    def test_no_binders(self):
+        assert (
+            find_theorem_binders("theorem trivial : True := trivial\n", "trivial") == []
+        )
+
+    def test_unknown_name(self):
+        assert find_theorem_binders("theorem foo (h : P) : Q := sorry\n", "bar") == []
+
+    def test_lemma_keyword(self):
+        src = "lemma bar (h : 1 = 1) : True := trivial\n"
+        texts = [b[0] for b in find_theorem_binders(src, "bar")]
+        assert texts == ["(h : 1 = 1)"]
+
+
+class TestExplicitHypotheses:
+    def test_filters_out_implicit_and_instance(self):
+        src = "theorem foo (h : P) {x : Nat} [DecidableEq α] : Q := sorry"
+        binders = find_theorem_binders(src, "foo")
+        explicit = explicit_hypotheses(binders)
+        assert [b[0] for b in explicit] == ["(h : P)"]
+
+    def test_only_keeps_colon_paren_groups(self):
+        src = "theorem foo (h : P) (a b c : Nat) (no_colon_here) : Q := sorry"
+        binders = find_theorem_binders(src, "foo")
+        explicit = [b[0] for b in explicit_hypotheses(binders)]
+        # Last group has no colon, so it's not treated as a hypothesis.
+        assert explicit == ["(h : P)", "(a b c : Nat)"]
+
+
+class TestDropBinder:
+    def test_removes_binder_and_one_leading_space(self):
+        src = "theorem foo (h1 : P) (h2 : Q) : R := sorry"
+        binders = find_theorem_binders(src, "foo")
+        # Drop h2
+        _, start, end = binders[1]
+        out = drop_binder(src, start, end)
+        assert out == "theorem foo (h1 : P) : R := sorry"
+
+    def test_first_binder_with_no_leading_space_is_safe(self):
+        # Synthetic: drop a binder at offset 0 (would not happen in real Lean
+        # source but the helper shouldn't crash).
+        out = drop_binder("(h : P) rest", 0, 7)
+        assert out == " rest"
+
+
+def test_line_of_offset_one_indexed():
+    src = "a\nbb\nccc\n"
+    assert line_of_offset(src, 0) == 1
+    assert line_of_offset(src, 2) == 2
+    assert line_of_offset(src, 5) == 3


### PR DESCRIPTION
## Summary      
Adds `lean_minimal_hypotheses`: for each explicit `(h : T)` hypothesis of a theorem, drops it and re-elaborates via the LSP overlay (the same `update_file_content` + `get_diagnostics` pattern used by `lean_verify` and `lean_multi_attempt`). Reports load-bearing vs removable per hypothesis.        
                                                                                      
Useful for "minimum hypotheses needed" / counterfactual reasoning when sharpening a theorem statement.                                                                        
                  
## Behavior                                                                         
- Skips implicit `{x : α}` and instance `[inst : C]` binders (those are inferable / always load-bearing in practice).                                     
- Does not rewrite the proof body. If the body names `h` by reference, the modified file fails to elaborate and we report `load-bearing`.                                                              
- Per-hypothesis error count is compared to a pre-modification baseline, so pre-existing errors elsewhere in the file don't poison the verdict.            
- Original file content is restored in a `finally` block (mirrors `lean_verify`).   
- For each load-bearing hypothesis, the verdict includes a breaks list -- every new error (line + column + message) produced by removing that binder -- pinpointing where in the proof body the hypothesis was used. 
                                                                                      
## Files                                                                            
- `src/lean_lsp_mcp/minimal_hypotheses.py` — pure-Python binder parser.             
- `src/lean_lsp_mcp/models.py` — `MinimalHypothesesResult` / `HypothesisVerdict` / `HypothesisStatus`.                                         
- `src/lean_lsp_mcp/server.py` — tool registration alongside `lean_verify`.         
- `tests/unit/test_minimal_hypotheses.py` — 13 unit tests for the parser helpers (no Lean install required).
- `tests/test_minimal_hypotheses.py` — 5 async integration tests using `mcp_client_factory`, marked `@pytest.mark.slow`.