### PR TITLE
chore: Mark code-execution tools non-read-only

### DIFF
--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -1595,8 +1595,9 @@ def _multi_attempt_lsp(
     "lean_multi_attempt",
     annotations=ToolAnnotations(
         title="Multi-Attempt",
-        readOnlyHint=True,
-        idempotentHint=True,
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
         openWorldHint=False,
     ),
 )
@@ -1629,8 +1630,9 @@ async def multi_attempt(
     "lean_run_code",
     annotations=ToolAnnotations(
         title="Run Code",
-        readOnlyHint=True,
-        idempotentHint=True,
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
         openWorldHint=False,
     ),
 )
@@ -2269,8 +2271,9 @@ def get_widget_source(
     "lean_profile_proof",
     annotations=ToolAnnotations(
         title="Profile Proof",
-        readOnlyHint=True,
-        idempotentHint=True,
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
         openWorldHint=False,
     ),
 )

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -251,6 +251,14 @@ def test_server_configures_required_bearer_auth(
         importlib.reload(server)
 
 
+def test_code_execution_tools_are_not_marked_read_only() -> None:
+    for tool_name in ("lean_multi_attempt", "lean_run_code", "lean_profile_proof"):
+        tool = server.mcp._tool_manager.get_tool(tool_name)
+        assert tool is not None
+        assert tool.annotations.readOnlyHint is False
+        assert tool.annotations.idempotentHint is False
+
+
 def test_rate_limited_allows_within_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     times = iter([100, 101])
     monkeypatch.setattr(server.time, "time", lambda: next(times))


### PR DESCRIPTION
Marks `lean_multi_attempt`, `lean_run_code`, and `lean_profile_proof` as non-read-only and non-idempotent because they execute caller-supplied Lean/tactic code or temporary Lean files.

Adds a regression test for the MCP tool annotations.
