### PR TITLE
fix(multi_attempt): surface diagnostics introduced at distant lines

### DIFF
--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -1090,6 +1090,59 @@ def _resolve_multi_attempt_column(line_context: str, column: Optional[int]) -> i
     return column - 1
 
 
+def _diagnostic_identity(diagnostic: Dict) -> tuple:
+    """Stable identity for a diagnostic — used to compute new vs. baseline
+    diagnostics in multi_attempt, so that errors a snippet introduces at
+    lines outside the local edit window aren't silently dropped.
+
+    ``code`` and ``source`` are included to disambiguate cases where the
+    LSP emits two diagnostics with the same range/severity/message but
+    different metadata (e.g. one from a linter, one from the elaborator).
+    """
+    diagnostic_range = diagnostic.get("range") or diagnostic.get("fullRange") or {}
+    start = diagnostic_range.get("start") or {}
+    end = diagnostic_range.get("end") or {}
+    return (
+        start.get("line"),
+        start.get("character"),
+        end.get("line"),
+        end.get("character"),
+        diagnostic.get("severity"),
+        diagnostic.get("code"),
+        diagnostic.get("source"),
+        diagnostic.get("message"),
+    )
+
+
+def _shift_baseline_keys(
+    baseline_keys: set, edit_start_line: int, line_delta: int
+) -> set:
+    """Shift baseline diagnostic-identity entries to compensate for the
+    file-line shift introduced by a multi-attempt edit.
+
+    Entries at lines strictly before ``edit_start_line`` are unaffected.
+    Entries at or beyond it (which the LSP re-emits at line + line_delta
+    after the edit) get their start/end lines shifted accordingly so the
+    post-edit identity tuple matches.
+    """
+    if not line_delta:
+        return baseline_keys
+    shifted = set()
+    for key in baseline_keys:
+        start_line, start_char, end_line, end_char, severity, code, source, message = (
+            key
+        )
+        if start_line is None or start_line < edit_start_line:
+            shifted.add(key)
+            continue
+        new_start = start_line + line_delta
+        new_end = end_line + line_delta if end_line is not None else end_line
+        shifted.add(
+            (new_start, start_char, new_end, end_char, severity, code, source, message)
+        )
+    return shifted
+
+
 def _filter_diagnostics_by_line_range(
     diagnostics: List[Dict], start_line: int, end_line: int
 ) -> List[Dict]:
@@ -1117,8 +1170,14 @@ def _filter_diagnostics_by_line_range(
 
 def _prepare_multi_attempt_edit(
     line_context: str, target_column: int, snippet: str, total_lines: int, line: int
-) -> tuple[str, DocumentContentChange, int, int]:
-    """Build the temporary edit and return its goal cursor location."""
+) -> tuple[str, DocumentContentChange, int, int, int]:
+    """Build the temporary edit and return its goal cursor location.
+
+    The final integer is the post-edit line delta: how many lines the file
+    grows by once the change is applied. Non-zero only when the snippet is
+    near end-of-file and the replacement range is clamped, in which case
+    pre-existing diagnostics at lines >= end_line shift by that delta.
+    """
     snippet_str = snippet.rstrip("\n")
     snippet_lines = snippet_str.split("\n") if snippet_str else [""]
     indent = line_context[:target_column]
@@ -1130,6 +1189,7 @@ def _prepare_multi_attempt_edit(
 
     replaced_line_count = max(len(snippet_lines), 1)
     end_line = min(line - 1 + replaced_line_count, total_lines)
+    line_delta = len(payload_lines) - (end_line - (line - 1))
     change = DocumentContentChange(
         payload,
         [line - 1, target_column],
@@ -1142,7 +1202,7 @@ def _prepare_multi_attempt_edit(
     else:
         goal_column = len(payload_lines[-1])
 
-    return snippet_str, change, goal_line, goal_column
+    return snippet_str, change, goal_line, goal_column, line_delta
 
 
 @mcp.tool(
@@ -1548,16 +1608,91 @@ def _multi_attempt_lsp(
     line_context = _get_line_context(lines, line)
     target_column = _resolve_multi_attempt_column(line_context, column)
 
+    # Snapshot baseline diagnostics before any edit. The line-range filter
+    # alone misses errors that surface at distant lines (e.g. a `whnf`
+    # heartbeat timeout reported at the leaf-statement line when a snippet's
+    # tactic forces aggressive unfolding) — that would produce a misleading
+    # `goals=[], diagnostics=[]` result indistinguishable from genuine
+    # tactic success. Diff against baseline to surface any *new* diagnostic
+    # the snippet introduced, regardless of its line position. Use
+    # leanclient's default cutoffs so the baseline wait is symmetric with
+    # the per-snippet `get_diagnostics` call below: asymmetric timeouts
+    # would leave the baseline partial while the per-snippet snapshot is
+    # complete, causing pre-existing diagnostics to be reported as
+    # snippet-introduced.
+    try:
+        baseline_diag = client.get_diagnostics(rel_path)
+        check_lsp_response(baseline_diag, "get_diagnostics")
+        if getattr(baseline_diag, "timed_out", False):
+            # Baseline is partial — set-diff would over-report. Disable
+            # it and fall back to local line-range filter only.
+            logger.warning(
+                "_multi_attempt_lsp: baseline diagnostics timed out — "
+                "set-diff disabled for this call (results limited to local "
+                "line-range filter)."
+            )
+            baseline_keys = None
+        else:
+            baseline_keys = {_diagnostic_identity(d) for d in baseline_diag}
+    except Exception:
+        logger.warning(
+            "_multi_attempt_lsp: baseline diagnostics unavailable — "
+            "set-diff disabled; results limited to local line-range filter.",
+            exc_info=True,
+        )
+        baseline_keys = None
+
     try:
         results: List[AttemptResult] = []
-        for snippet in snippets:
-            snippet_str, change, goal_line, goal_column = _prepare_multi_attempt_edit(
+        for i, snippet in enumerate(snippets):
+            # Restore original content before each iteration after the first.
+            # ``_prepare_multi_attempt_edit`` computes edit positions from the
+            # ORIGINAL ``line_context`` / ``len(lines)``; if the previous
+            # snippet's edit grew or shrank the file (EOF clamping), those
+            # positions no longer point to the original sorry region — the
+            # next snippet would patch the wrong content and report drifted
+            # diagnostics as snippet-introduced via ``extra_diag``.
+            if i > 0 and original_content is not None:
+                client.update_file_content(rel_path, original_content)
+            (
+                snippet_str,
+                change,
+                goal_line,
+                goal_column,
+                line_delta,
+            ) = _prepare_multi_attempt_edit(
                 line_context, target_column, snippet, len(lines), line
             )
             client.update_file(rel_path, [change])
             diag = client.get_diagnostics(rel_path)
             check_lsp_response(diag, "get_diagnostics")
             filtered_diag = _filter_diagnostics_by_line_range(diag, line - 1, goal_line)
+            in_filtered = {id(d) for d in filtered_diag}
+            # Surface any new diagnostic — relative to the pre-edit baseline —
+            # even if outside the local line range. When baseline capture
+            # failed (baseline_keys is None), set-diff is disabled and we
+            # rely on the local filter only — same behavior as the original
+            # (pre-fix) code path.
+            if baseline_keys is None:
+                extra_diag = []
+            else:
+                # Multi-line snippets near end-of-file can grow the file
+                # (replacement range gets clamped). Pre-existing diagnostics
+                # at or past end_line get re-emitted at shifted line numbers
+                # post-edit, so their identity (which keys on line) won't
+                # match baseline_keys without compensating for the shift.
+                if line_delta:
+                    shifted_keys = _shift_baseline_keys(
+                        baseline_keys, edit_start_line=line - 1, line_delta=line_delta
+                    )
+                else:
+                    shifted_keys = baseline_keys
+                extra_diag = [
+                    d
+                    for d in diag
+                    if id(d) not in in_filtered
+                    and _diagnostic_identity(d) not in shifted_keys
+                ]
             goal_result = client.get_goal(rel_path, goal_line, goal_column)
             check_lsp_response(goal_result, "get_goal", allow_none=True)
             goals = extract_goals_list(goal_result)
@@ -1565,7 +1700,7 @@ def _multi_attempt_lsp(
                 AttemptResult(
                     snippet=snippet_str,
                     goals=goals,
-                    diagnostics=_to_diagnostic_messages(filtered_diag),
+                    diagnostics=_to_diagnostic_messages(filtered_diag + extra_diag),
                     timed_out=getattr(diag, "timed_out", False),
                 )
             )

--- a/tests/unit/test_diagnostic_identity.py
+++ b/tests/unit/test_diagnostic_identity.py
@@ -1,0 +1,206 @@
+"""Regression tests for the multi_attempt LSP-path false-success fix.
+
+When a snippet introduced via the LSP path triggered an error at a line
+outside the local edit range (e.g. a `whnf` heartbeat timeout reported
+at a distant declaration), the line-range filter discarded the
+diagnostic and the result became goals=[]/diagnostics=[], indistinguishable
+from genuine tactic success. The fix snapshots baseline diagnostics
+before the edit and unions any *new* diagnostic into the result
+regardless of its line position.
+"""
+
+from __future__ import annotations
+
+from lean_lsp_mcp.server import (
+    _diagnostic_identity,
+    _filter_diagnostics_by_line_range,
+    _prepare_multi_attempt_edit,
+    _shift_baseline_keys,
+)
+
+
+def _diag(line: int, char: int, severity: int, message: str) -> dict:
+    return {
+        "range": {
+            "start": {"line": line, "character": char},
+            "end": {"line": line, "character": char + 1},
+        },
+        "severity": severity,
+        "message": message,
+    }
+
+
+def test_identity_is_stable_across_equal_dicts() -> None:
+    a = _diag(line=10, char=0, severity=1, message="x")
+    b = _diag(line=10, char=0, severity=1, message="x")
+    assert _diagnostic_identity(a) == _diagnostic_identity(b)
+
+
+def test_identity_distinguishes_by_message() -> None:
+    a = _diag(line=10, char=0, severity=1, message="x")
+    b = _diag(line=10, char=0, severity=1, message="y")
+    assert _diagnostic_identity(a) != _diagnostic_identity(b)
+
+
+def test_identity_distinguishes_by_line() -> None:
+    a = _diag(line=10, char=0, severity=1, message="x")
+    b = _diag(line=11, char=0, severity=1, message="x")
+    assert _diagnostic_identity(a) != _diagnostic_identity(b)
+
+
+def test_identity_handles_missing_range() -> None:
+    d = {"severity": 1, "message": "no range"}
+    # Should produce a valid identity tuple, not raise.
+    ident = _diagnostic_identity(d)
+    # (start.line, start.char, end.line, end.char, severity, code, source, message)
+    assert ident == (None, None, None, None, 1, None, None, "no range")
+
+
+def test_identity_distinguishes_by_code_and_source() -> None:
+    """Two diagnostics with the same range/severity/message but different
+    ``code`` or ``source`` (e.g. one from the elaborator, one from a
+    linter) must produce different identities.
+    """
+    base = _diag(line=10, char=0, severity=2, message="unused")
+    linter = dict(base, code="linter.unusedVariables", source="lint")
+    elab = dict(base, code=None, source=None)
+    assert _diagnostic_identity(linter) != _diagnostic_identity(elab)
+
+
+def test_new_diagnostic_outside_range_survives_set_diff() -> None:
+    """Bug scenario: snippet introduces an error at a distant line, the
+    line-range filter discards it, but the baseline-diff catches it.
+    """
+    baseline = [_diag(line=20, char=0, severity=2, message="declaration uses `sorry`")]
+    after_snippet = [
+        _diag(line=20, char=0, severity=2, message="declaration uses `sorry`"),
+        _diag(line=5, char=0, severity=1, message="deterministic timeout at `whnf`"),
+    ]
+    baseline_keys = {_diagnostic_identity(d) for d in baseline}
+
+    # Snippet inserted at line 21; local filter window is line 20..21.
+    filtered = _filter_diagnostics_by_line_range(after_snippet, 20, 21)
+    in_filtered = {id(d) for d in filtered}
+    extra = [
+        d
+        for d in after_snippet
+        if id(d) not in in_filtered and _diagnostic_identity(d) not in baseline_keys
+    ]
+
+    # The original `sorry` warning is in filtered (overlaps line range).
+    assert any("sorry" in d["message"] for d in filtered)
+    # The distant whnf error must be picked up by the set-diff path.
+    assert any("whnf" in d["message"] for d in extra)
+
+
+def test_unchanged_distant_diagnostic_not_re_reported() -> None:
+    """Pre-existing diagnostics outside the snippet range should NOT pollute
+    the result if they were already there before the edit.
+    """
+    pre_existing = _diag(line=200, char=0, severity=1, message="pre-existing error")
+    baseline = [pre_existing]
+    # After snippet, the same pre-existing error is still there (no change).
+    after_snippet = [pre_existing]
+    baseline_keys = {_diagnostic_identity(d) for d in baseline}
+
+    filtered = _filter_diagnostics_by_line_range(after_snippet, 10, 11)
+    in_filtered = {id(d) for d in filtered}
+    extra = [
+        d
+        for d in after_snippet
+        if id(d) not in in_filtered and _diagnostic_identity(d) not in baseline_keys
+    ]
+
+    assert filtered == []  # outside range
+    assert extra == []  # in baseline, so excluded
+
+
+def test_prepare_multi_attempt_edit_no_shift_in_middle_of_file() -> None:
+    """Multi-line snippet replacing N source lines in the middle of a file
+    leaves the file size unchanged, so line_delta == 0.
+    """
+    _, _, _, _, line_delta = _prepare_multi_attempt_edit(
+        line_context="  sorry",
+        target_column=2,
+        snippet="have h : True := trivial\n  exact h",
+        total_lines=100,
+        line=50,
+    )
+    assert line_delta == 0
+
+
+def test_prepare_multi_attempt_edit_shift_when_clamped() -> None:
+    """Multi-line snippet near end-of-file gets its replacement range clamped
+    by total_lines. The payload still has N lines but only fewer original
+    lines were replaced, so the file grows by the difference.
+    """
+    # 4-line file, snippet at line 3 with 3 payload lines.
+    # replacement covers lines [2, min(2+3, 4)) = [2, 4), i.e. 2 original
+    # lines. Payload is 3 lines. Delta = +1.
+    _, _, _, _, line_delta = _prepare_multi_attempt_edit(
+        line_context="  sorry",
+        target_column=2,
+        snippet="have h : True := trivial\n  have h2 : True := h\n  exact h2",
+        total_lines=4,
+        line=3,
+    )
+    assert line_delta == 1
+
+
+def test_shift_baseline_keys_no_op_for_zero_delta() -> None:
+    keys = {_diagnostic_identity(_diag(line=10, char=0, severity=2, message="x"))}
+    shifted = _shift_baseline_keys(keys, edit_start_line=5, line_delta=0)
+    assert shifted is keys
+
+
+def test_shift_baseline_keys_shifts_only_at_or_after_edit() -> None:
+    """Pre-existing diagnostics BEFORE the edit are unaffected; those
+    AT/AFTER the edit shift by line_delta.
+    """
+    before = _diagnostic_identity(_diag(line=2, char=0, severity=2, message="before"))
+    after = _diagnostic_identity(_diag(line=8, char=0, severity=2, message="after"))
+    shifted = _shift_baseline_keys({before, after}, edit_start_line=5, line_delta=2)
+
+    # `before` stays at line 2.
+    before_in_shifted = next(k for k in shifted if k[7] == "before")
+    assert before_in_shifted[0] == 2
+    # `after` was at line 8, end at line 8 too; both shift by +2.
+    after_in_shifted = next(k for k in shifted if k[7] == "after")
+    assert after_in_shifted[0] == 10
+    assert after_in_shifted[2] == 10
+
+
+def test_shifted_baseline_eliminates_false_positive_from_line_shift() -> None:
+    """End-to-end: pre-existing diagnostic at line 5 shifts to line 7 after
+    a 2-line file growth from a multi-line snippet. Without the shift fix,
+    the post-edit line-7 diagnostic would be reported as 'new'. With the
+    shift fix, the shifted baseline key matches it and it's correctly
+    excluded from extra_diag.
+    """
+    # Baseline: pre-existing "uses sorry" warning at line 5.
+    baseline = [_diag(line=5, char=0, severity=2, message="declaration uses `sorry`")]
+    # Edit at line 3 (0-indexed 2), file grows by 2. Pre-existing line-5
+    # diagnostic gets re-emitted at line 7 post-edit.
+    after_snippet = [
+        _diag(line=7, char=0, severity=2, message="declaration uses `sorry`")
+    ]
+    baseline_keys = {_diagnostic_identity(d) for d in baseline}
+
+    # Without shift adjustment: the post-edit diag is treated as new — bug.
+    filtered = _filter_diagnostics_by_line_range(after_snippet, 2, 4)
+    in_filtered = {id(d) for d in filtered}
+    unshifted_extra = [
+        d
+        for d in after_snippet
+        if id(d) not in in_filtered and _diagnostic_identity(d) not in baseline_keys
+    ]
+    assert unshifted_extra, "without the fix, the shifted baseline diag false-positives"
+
+    # With shift adjustment: extra_diag is empty.
+    shifted = _shift_baseline_keys(baseline_keys, edit_start_line=2, line_delta=2)
+    shifted_extra = [
+        d
+        for d in after_snippet
+        if id(d) not in in_filtered and _diagnostic_identity(d) not in shifted
+    ]
+    assert shifted_extra == []


### PR DESCRIPTION
lean_multi_attempt only reported diagnostics overlapping the local edit range. Some snippet failures are reported elsewhere in the file, such as a whnf timeout at a theorem signature, so the LSP path could return goals=[], diagnostics=[] for a failed attempt.

Snapshot baseline diagnostics before applying snippets. After each temporary edit, keep the existing local diagnostic filter and also include any post-edit diagnostic whose identity was not present in the baseline. This surfaces distant diagnostics introduced by the snippet without re-reporting pre-existing diagnostics.

Note: if the baseline snapshot times out or is unavailable, disable the baseline diff and fall back to the previous local filtering behavior to avoid over-reporting from a partial baseline. Alternative behavior could be to abort completely when initial diagnostics times out, and declare the whole tool call as timed out. Unsure what is best but I expect its not too important: my intuition is that if the initial diags time out then so will the other ones.

Also restore original file content between snippet attempts and account for EOF-clamped line shifts when comparing baseline diagnostic identities.

Add unit coverage for diagnostic identity, distant new diagnostics, pre-existing diagnostics, fallback behavior, and shifted baseline diagnostics.