### PR TITLE
Make lean_build cache fetch opt-in

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -385,4 +385,8 @@ Note: We use a simplified version, [LeanHammer](https://github.com/JOSHCLUNE/Lea
 
 #### lean_build
 
-Rebuild the Lean project and restart the Lean LSP server.
+Run `lake build` and restart the Lean LSP server.
+
+Optional flags:
+- `clean=true`: run `lake clean` before building. This is slow and should only be used when a clean rebuild is needed.
+- `fetch_cache=true`: run `lake exe cache get` before building. This can take a long time and should only be used when fetching missing dependency caches is needed.

--- a/src/lean_lsp_mcp/instructions.py
+++ b/src/lean_lsp_mcp/instructions.py
@@ -13,7 +13,7 @@ INSTRUCTIONS = """## General Rules
 - **lean_declaration_file**: Get declaration source. Use sparingly (large output).
 - **lean_run_code**: Run standalone snippet. Use rarely.
 - **lean_verify**: Axiom check + source scan. Use fully qualified name (e.g. `Ns.thm`).
-- **lean_build**: Rebuild + restart LSP. Only if needed (new imports). SLOW!
+- **lean_build**: Run `lake build` + restart LSP. Only if needed (new imports). Use `fetch_cache=true` only for missing dependency caches. SLOW!
 - **lean_profile_proof**: Profile a theorem for performance. Shows tactic hotspots. SLOW!
 
 ## Search Tools (rate limited)

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -539,6 +539,9 @@ async def lsp_build(
         Optional[str], Field(description="Path to Lean project")
     ] = None,
     clean: Annotated[bool, Field(description="Run lake clean first (slow)")] = False,
+    fetch_cache: Annotated[
+        bool, Field(description="Run lake exe cache get before building (slow)")
+    ] = False,
     output_lines: Annotated[
         int, Field(description="Return last N lines of build log (0=none)")
     ] = 20,
@@ -564,7 +567,9 @@ async def lsp_build(
         )
 
     async def build_factory() -> BuildResult:
-        return await _run_build(ctx, lean_project_path_obj, clean, output_lines)
+        return await _run_build(
+            ctx, lean_project_path_obj, clean, fetch_cache, output_lines
+        )
 
     app_ctx = ctx.request_context.lifespan_context
     coordinator = app_ctx.build_coordinator
@@ -577,6 +582,7 @@ async def _run_build(
     ctx: Context,
     lean_project_path_obj: Path,
     clean: bool,
+    fetch_cache: bool,
     output_lines: int,
 ) -> BuildResult:
     log_lines: List[str] = []
@@ -656,26 +662,26 @@ async def _run_build(
             await _consume_build_output(clean_proc)
             await clean_proc.wait()
 
-        await _safe_report_progress(
-            ctx, progress=2, total=16, message="Running `lake exe cache get`"
-        )
-        cache_proc = await _run_proc(
-            "lake",
-            "exe",
-            "cache",
-            "get",
-            cwd=lean_project_path_obj,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
-        await _consume_build_output(cache_proc)
-        await cache_proc.wait()
+        if fetch_cache:
+            await _safe_report_progress(
+                ctx, progress=2, total=16, message="Running `lake exe cache get`"
+            )
+            cache_proc = await _run_proc(
+                "lake",
+                "exe",
+                "cache",
+                "get",
+                cwd=lean_project_path_obj,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            await _consume_build_output(cache_proc)
+            await cache_proc.wait()
 
         # Run build with progress reporting
         process = await _run_proc(
             "lake",
             "build",
-            "--verbose",
             cwd=lean_project_path_obj,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,

--- a/tests/unit/test_build_progress.py
+++ b/tests/unit/test_build_progress.py
@@ -85,7 +85,7 @@ def patch_build():
 @pytest.mark.asyncio
 async def test_progress_parsing(build_mocks, patch_build, tmp_path):
     """Progress markers [n/m] are parsed and reported."""
-    project, ctx, cache_proc, build_proc = build_mocks
+    project, ctx, _cache_proc, build_proc = build_mocks
     progress_calls = []
     ctx.report_progress = AsyncMock(
         side_effect=lambda progress, total, message: progress_calls.append(
@@ -96,7 +96,7 @@ async def test_progress_parsing(build_mocks, patch_build, tmp_path):
     build_proc.stdout.read = make_read(
         b"[0/8] Ran job\n[1/8] Built A\n[2/10] Built B\n"
     )
-    patch_build.side_effect = [cache_proc, build_proc]
+    patch_build.side_effect = [build_proc]
 
     await lsp_build(ctx, lean_project_path=str(project))
 
@@ -110,11 +110,11 @@ async def test_progress_parsing(build_mocks, patch_build, tmp_path):
 @pytest.mark.asyncio
 async def test_filters_trace_lines(build_mocks, patch_build, tmp_path):
     """Verbose trace: and LEAN_PATH= lines are filtered from output."""
-    project, ctx, cache_proc, build_proc = build_mocks
+    project, ctx, _cache_proc, build_proc = build_mocks
     build_proc.stdout.read = make_read(
         b"[0/2] Built A\ntrace: .> LEAN_PATH=/x lean cmd\n[1/2] Built B\n"
     )
-    patch_build.side_effect = [cache_proc, build_proc]
+    patch_build.side_effect = [build_proc]
 
     result = await lsp_build(ctx, lean_project_path=str(project), output_lines=100)
 
@@ -126,10 +126,10 @@ async def test_filters_trace_lines(build_mocks, patch_build, tmp_path):
 @pytest.mark.asyncio
 async def test_output_truncation(build_mocks, patch_build, tmp_path):
     """output_lines parameter truncates to last N lines."""
-    project, ctx, cache_proc, build_proc = build_mocks
+    project, ctx, _cache_proc, build_proc = build_mocks
     lines = b"\n".join(f"[{i}/50] Built M{i}".encode() for i in range(50))
     build_proc.stdout.read = make_read(lines + b"\nDone\n")
-    patch_build.side_effect = [cache_proc, build_proc]
+    patch_build.side_effect = [build_proc]
 
     result = await lsp_build(ctx, lean_project_path=str(project), output_lines=5)
 
@@ -140,14 +140,28 @@ async def test_output_truncation(build_mocks, patch_build, tmp_path):
 @pytest.mark.asyncio
 async def test_output_lines_zero(build_mocks, patch_build, tmp_path):
     """output_lines=0 returns empty output."""
-    project, ctx, cache_proc, build_proc = build_mocks
+    project, ctx, _cache_proc, build_proc = build_mocks
     build_proc.stdout.read = make_read(b"[0/1] Built\nDone\n")
-    patch_build.side_effect = [cache_proc, build_proc]
+    patch_build.side_effect = [build_proc]
 
     result = await lsp_build(ctx, lean_project_path=str(project), output_lines=0)
 
     assert result.output == ""
     assert result.success
+
+
+@pytest.mark.asyncio
+async def test_default_build_skips_cache_fetch(build_mocks, patch_build, tmp_path):
+    """Default build runs lake build without fetching caches."""
+    project, ctx, _cache_proc, build_proc = build_mocks
+    build_proc.stdout.read = make_read(b"Done\n")
+    patch_build.side_effect = [build_proc]
+
+    result = await lsp_build(ctx, lean_project_path=str(project), output_lines=100)
+
+    assert result.success
+    assert patch_build.await_count == 1
+    assert patch_build.await_args.args[:2] == ("lake", "build")
 
 
 @pytest.mark.asyncio
@@ -163,10 +177,18 @@ async def test_reports_cache_progress(build_mocks, patch_build, tmp_path):
     build_proc.stdout.read = make_read(b"Done\n")
     patch_build.side_effect = [cache_proc, build_proc]
 
-    await lsp_build(ctx, lean_project_path=str(project), output_lines=100)
+    await lsp_build(
+        ctx, lean_project_path=str(project), fetch_cache=True, output_lines=100
+    )
 
     # Should have reported cache fetch progress
     assert any("cache" in m.lower() for p, t, m in progress_calls)
+    assert patch_build.await_args_list[0].args[:4] == (
+        "lake",
+        "exe",
+        "cache",
+        "get",
+    )
 
 
 @pytest.mark.asyncio
@@ -179,7 +201,13 @@ async def test_setup_subprocesses_pipe_output(build_mocks, patch_build, tmp_path
     build_proc.stdout.read = make_read(b"Done\n")
     patch_build.side_effect = [clean_proc, cache_proc, build_proc]
 
-    await lsp_build(ctx, lean_project_path=str(project), clean=True, output_lines=100)
+    await lsp_build(
+        ctx,
+        lean_project_path=str(project),
+        clean=True,
+        fetch_cache=True,
+        output_lines=100,
+    )
 
     clean_call = patch_build.await_args_list[0]
     cache_call = patch_build.await_args_list[1]
@@ -192,10 +220,10 @@ async def test_setup_subprocesses_pipe_output(build_mocks, patch_build, tmp_path
 @pytest.mark.asyncio
 async def test_handles_long_verbose_line(build_mocks, patch_build, tmp_path):
     """Long verbose lines do not overflow the stream reader limit."""
-    project, ctx, cache_proc, build_proc = build_mocks
+    project, ctx, _cache_proc, build_proc = build_mocks
     long_trace = b"trace: " + (b"x" * (70 * 1024)) + b"\n[1/2] Built A\nDone\n"
     build_proc.stdout.read = make_read(long_trace)
-    patch_build.side_effect = [cache_proc, build_proc]
+    patch_build.side_effect = [build_proc]
 
     result = await lsp_build(ctx, lean_project_path=str(project), output_lines=100)
 
@@ -209,13 +237,13 @@ async def test_lsp_build_continues_when_client_close_fails(
     build_mocks, patch_build, tmp_path
 ):
     """Pre-build client close failure is logged and does not abort the build."""
-    project, ctx, cache_proc, build_proc = build_mocks
+    project, ctx, _cache_proc, build_proc = build_mocks
     failing_client = _FailingClient()
     failing_client.project_path = tmp_path / "old-proj"
     ctx.request_context.lifespan_context.client = failing_client
 
     build_proc.stdout.read = make_read(b"[0/1] Built\nDone\n")
-    patch_build.side_effect = [cache_proc, build_proc]
+    patch_build.side_effect = [build_proc]
 
     result = await lsp_build(ctx, lean_project_path=str(project), output_lines=100)
 


### PR DESCRIPTION
## Summary

- make `lean_build` skip `lake exe cache get` by default
- add a `fetch_cache` flag for callers that explicitly want to fetch dependency caches before building
- document the distinction between normal builds, `clean=true`, and `fetch_cache=true`

## Motivation

`lake exe cache get` can be very slow, especially in mathlib projects, and the normal `lean_build` path should match the usual `lake build` workflow. Cache fetching remains available for fresh clones or missing dependency caches, but agents no longer pay that cost on every build call.

## Tests

- `uv run --with pytest --with pytest-asyncio pytest tests/unit/test_build_progress.py`
- `uv run --extra lint ruff check src/lean_lsp_mcp/server.py src/lean_lsp_mcp/instructions.py tests/unit/test_build_progress.py`
