### PR TITLE
Sync uv.lock package version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "lean-lsp-mcp"
-version = "0.26.1"
+version = "0.26.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary

- update the editable `lean-lsp-mcp` package entry in `uv.lock` from `0.26.1` to `0.26.2`
- update the lockfile revision generated by `uv`

## Motivation

`pyproject.toml` currently declares `lean-lsp-mcp` as `0.26.2`, but `uv.lock` still records the editable package as `0.26.1`. Running `uv run` refreshes these two lockfile fields, so committing the sync avoids incidental dirty worktrees.

## Tests

- `uv run python - <<'PY'\nimport importlib.metadata as m\nprint(m.version('lean-lsp-mcp'))\nPY`
