### PR TITLE
Fix severity schema for Gemini/Vertex function calling (#185)

### DIFF
--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -56,7 +56,6 @@ from lean_lsp_mcp.models import (
     CompletionsResult,
     DeclarationInfo,
     DiagnosticMessage,
-    DiagnosticSeverity,
     # Wrapper models for list-returning tools
     DiagnosticsResult,
     InteractiveDiagnosticsResult,
@@ -793,7 +792,7 @@ def _to_diagnostic_messages(diagnostics: List[Dict]) -> List[DiagnosticMessage]:
 def _process_diagnostics(
     diagnostics: List[Dict],
     build_success: bool,
-    severity: Optional[DiagnosticSeverity] = None,
+    severity: Optional[str] = None,
     timed_out: bool = False,
 ) -> DiagnosticsResult:
     """Process diagnostics, extracting dependency paths from build stderr.
@@ -823,7 +822,7 @@ def _process_diagnostics(
 
         # Normal diagnostic from the queried file
         severity_str = DIAGNOSTIC_SEVERITY.get(severity_int, f"unknown({severity_int})")
-        if severity is not None and severity_str != severity.value:
+        if severity is not None and severity_str != severity:
             continue
         items.append(
             DiagnosticMessage(
@@ -872,8 +871,16 @@ def diagnostic_messages(
         ),
     ] = False,
     severity: Annotated[
-        Optional[DiagnosticSeverity],
-        Field(description="Filter by severity level. Returns all levels when omitted."),
+        Optional[Literal["error", "warning", "info", "hint"]],
+        # json_schema_extra forces an explicit top-level `type` onto the
+        # property schema. Without it the emitted schema is a bare
+        # anyOf/enum union with no `type`, which Google Gemini/Vertex
+        # function-calling rejects ("schema didn't specify the schema type
+        # field"). See issue #185.
+        Field(
+            description="Filter by severity level. Returns all levels when omitted.",
+            json_schema_extra={"type": "string"},
+        ),
     ] = None,
 ) -> DiagnosticsResult | InteractiveDiagnosticsResult:
     """Get compiler diagnostics (errors, warnings, infos) for a Lean file."""

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -783,6 +783,40 @@ def test_process_diagnostics_build_failure_excluded_regardless_of_filter() -> No
     assert result.success is False
 
 
+def test_process_diagnostics_accepts_plain_string_severity() -> None:
+    """The tool now passes severity as a plain string (Literal), not an enum.
+
+    See issue #185: the parameter type changed from a str-Enum to a Literal so
+    the emitted JSON schema is Gemini/Vertex compatible.
+    """
+    result = server._process_diagnostics(
+        _MIXED_DIAGNOSTICS, build_success=True, severity="warning"
+    )
+    assert len(result.items) == 1
+    assert result.items[0].severity == "warning"
+
+
+def test_diagnostic_messages_severity_schema_is_vertex_compatible() -> None:
+    """Regression test for #185.
+
+    Google Gemini/Vertex function-calling rejects a parameter schema that lacks
+    an explicit top-level ``type`` field, and cannot resolve JSON-Schema
+    ``$ref``/``$defs``. The ``severity`` parameter of ``lean_diagnostic_messages``
+    must therefore expose a top-level ``type`` and contain no ``$ref`` while
+    still constraining the value to the four severity levels.
+    """
+    tools = asyncio.run(server.mcp.list_tools())
+    tool = next(t for t in tools if t.name == "lean_diagnostic_messages")
+    severity = tool.inputSchema["properties"]["severity"]
+    severity_json = json.dumps(severity)
+
+    assert severity.get("type") == "string"
+    assert "$ref" not in severity_json
+    assert "DiagnosticSeverity" not in json.dumps(tool.inputSchema.get("$defs", {}))
+    for level in ("error", "warning", "info", "hint"):
+        assert level in severity_json
+
+
 def test_diagnostic_messages_passes_severity_to_process(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes #185.

## Problem
`lean_diagnostic_messages` typed its `severity` parameter as a `str` Enum (`DiagnosticSeverity`). Pydantic emits that as an `anyOf`/`$ref` union into `$defs` with **no top-level `type`**. Google Gemini/Vertex function-calling rejects this:

> functionDeclaration `parameters.severity` schema didn't specify the schema type field

Vertex also cannot resolve JSON-Schema `$ref`/`$defs`.

## Fix
- Switch the parameter to an inline `Literal["error", "warning", "info", "hint"]` (no `$ref`/`$defs`).
- Force an explicit `type: string` onto the property via `json_schema_extra`.
- `_process_diagnostics` now compares the value directly (was `severity.value`), so it accepts both the plain string from the tool and the `DiagnosticSeverity` enum still used in unit tests.

Emitted schema before → after:
```
before: {"anyOf": [{"$ref": "#/$defs/DiagnosticSeverity"}, {"type": "null"}], ...}   # no type, has $ref
after:  {"anyOf": [{"enum": [...], "type": "string"}, {"type": "null"}], "type": "string", ...}
```

## Tests
- `test_diagnostic_messages_severity_schema_is_vertex_compatible` — builds the live tool schema and asserts `severity` has a top-level `type`, contains no `$ref`, and still constrains to the four levels. Real regression guard for the reported failure.
- `test_process_diagnostics_accepts_plain_string_severity` — covers the new plain-string filter path.
- Full unit suite: 247 passed / 3 skipped; `ruff check` + `ruff format --check` clean.