### PR TITLE
Skip rate limits for self-hosted search backends; raise LeanSearch limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,11 +215,11 @@ This MCP server works out-of-the-box without any configuration. However, a few o
 - `LEAN_REPL_MEM_MB`: Max memory per REPL in MB (default: 8192). Only enforced on Linux/macOS.
 - `LEAN_LSP_MCP_TOKEN`: Secret token for bearer authentication when using `streamable-http` or `sse` transport. If set, bearer auth is required for every request.
 - `LEAN_BUILD_CONCURRENCY`: Build concurrency mode for `lean_build`. Options: `allow` (default), `cancel`, `share`.
-- `LEAN_STATE_SEARCH_URL`: URL for a self-hosted [premise-search.com](https://premise-search.com) instance.
-- `LEAN_HAMMER_URL`: URL for a self-hosted [Lean Hammer Premise Search](https://github.com/hanwenzhu/lean-premise-server) instance.
+- `LEAN_STATE_SEARCH_URL`: URL for a self-hosted [premise-search.com](https://premise-search.com) instance. Rate limits are skipped when set to a custom backend.
+- `LEAN_HAMMER_URL`: URL for a self-hosted [Lean Hammer Premise Search](https://github.com/hanwenzhu/lean-premise-server) instance. Rate limits are skipped when set to a custom backend.
 - `LEAN_LOOGLE_LOCAL`: Set to `true`, `1`, or `yes` to enable local loogle (see [Local Loogle](#local-loogle) section).
 - `LEAN_LOOGLE_CACHE_DIR`: Override the cache directory for local loogle (default: `~/.cache/lean-lsp-mcp/loogle`).
-- `LOOGLE_URL`: URL for a self-hosted Loogle instance (default: `https://loogle.lean-lang.org`).
+- `LOOGLE_URL`: URL for a self-hosted Loogle instance (default: `https://loogle.lean-lang.org`). Rate limits are skipped when set to a custom backend.
 - `LOOGLE_HEADERS`: JSON object of extra HTTP headers for Loogle requests (e.g. `'{"X-API-Key": "..."}'`).
 
 You can also often set these environment variables in your MCP client configuration:

--- a/src/lean_lsp_mcp/loogle.py
+++ b/src/lean_lsp_mcp/loogle.py
@@ -22,6 +22,10 @@ from lean_lsp_mcp.models import LoogleResult
 
 logger = logging.getLogger(__name__)
 
+# Public shared loogle instance. Rate limits only apply to this default; a
+# custom LOOGLE_URL (self-hosted backend) is not rate limited.
+DEFAULT_LOOGLE_URL = "https://loogle.lean-lang.org"
+
 
 def get_cache_dir() -> Path:
     if d := os.environ.get("LEAN_LOOGLE_CACHE_DIR"):
@@ -39,7 +43,7 @@ def loogle_remote(query: str, num_results: int) -> list[LoogleResult] | str:
     Set LOOGLE_URL to override the default endpoint.
     Set LOOGLE_HEADERS to a JSON object of extra headers (e.g. '{"X-API-Key": "..."}').
     """
-    base = os.environ.get("LOOGLE_URL", "https://loogle.lean-lang.org")
+    base = os.environ.get("LOOGLE_URL", DEFAULT_LOOGLE_URL)
     try:
         headers = {"User-Agent": "lean-lsp-mcp/0.1"}
         if extra := os.environ.get("LOOGLE_HEADERS"):

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -44,7 +44,7 @@ from lean_lsp_mcp.file_utils import (
     require_lean_project_path,
 )
 from lean_lsp_mcp.instructions import INSTRUCTIONS
-from lean_lsp_mcp.loogle import LoogleManager, loogle_remote
+from lean_lsp_mcp.loogle import DEFAULT_LOOGLE_URL, LoogleManager, loogle_remote
 from lean_lsp_mcp.repl import Repl, repl_enabled
 from lean_lsp_mcp.models import (
     AttemptResult,
@@ -463,9 +463,33 @@ if auth_token:
 mcp = FastMCP(**mcp_kwargs)
 
 
-def rate_limited(category: str, max_requests: int, per_seconds: int):
+# Default (shared, public) backends for the configurable search tools. Rate
+# limits exist to be a polite citizen of these shared services; when a user
+# points a tool at their own backend they are not rate limited.
+DEFAULT_STATE_SEARCH_URL = "https://premise-search.com"
+DEFAULT_HAMMER_URL = "http://leanpremise.net"
+
+
+def _custom_backend(env_var: str, default_url: str) -> bool:
+    """True when the user configured a self-hosted backend for a tool.
+
+    A custom (non-default) URL means requests do not hit the shared public
+    service, so the rate limit no longer applies.
+    """
+    configured = os.environ.get(env_var, "").strip()
+    return bool(configured) and configured.rstrip("/") != default_url.rstrip("/")
+
+
+def rate_limited(
+    category: str,
+    max_requests: int,
+    per_seconds: int,
+    bypass: Optional[Callable[[], bool]] = None,
+):
     def decorator(func):
         def _apply_rate_limit(args, kwargs):
+            if bypass is not None and bypass():
+                return True, None
             ctx = kwargs.get("ctx")
             if ctx is None:
                 if not args:
@@ -2207,7 +2231,11 @@ async def local_search(
         openWorldHint=True,
     ),
 )
-@rate_limited("leansearch", max_requests=3, per_seconds=30)
+# leansearch.net raised capacity to ~40 req/s (per-IP ~120 req/min) and asked
+# us to lift our previously very conservative 3 req/30s. This client-side
+# throttle mainly guards against runaway loops; the server enforces its own
+# per-IP limit, which the maintainers adjust dynamically as capacity allows.
+@rate_limited("leansearch", max_requests=90, per_seconds=30)
 async def leansearch(
     ctx: Context,
     query: Annotated[str, Field(description="Natural language or Lean term query")],
@@ -2295,15 +2323,17 @@ async def loogle(
         except Exception as e:
             logger.warning(f"Local loogle failed: {e}, falling back to remote")
 
-    # Fall back to remote (with rate limiting)
-    rate_limit = app_ctx.rate_limit["loogle"]
-    now = int(time.time())
-    rate_limit[:] = [t for t in rate_limit if now - t < 30]
-    if len(rate_limit) >= 3:
-        raise LeanToolError(
-            "Rate limit exceeded: 3 requests per 30s. Use --loogle-local to avoid limits."
-        )
-    rate_limit.append(now)
+    # Fall back to remote. Rate limit only the default public instance; a
+    # custom LOOGLE_URL (self-hosted backend) is not rate limited.
+    if not _custom_backend("LOOGLE_URL", DEFAULT_LOOGLE_URL):
+        rate_limit = app_ctx.rate_limit["loogle"]
+        now = int(time.time())
+        rate_limit[:] = [t for t in rate_limit if now - t < 30]
+        if len(rate_limit) >= 3:
+            raise LeanToolError(
+                "Rate limit exceeded: 3 requests per 30s. Use --loogle-local to avoid limits."
+            )
+        rate_limit.append(now)
 
     await _safe_report_progress(
         ctx,
@@ -2388,7 +2418,12 @@ async def leanfinder(
         openWorldHint=True,
     ),
 )
-@rate_limited("lean_state_search", max_requests=6, per_seconds=30)
+@rate_limited(
+    "lean_state_search",
+    max_requests=6,
+    per_seconds=30,
+    bypass=lambda: _custom_backend("LEAN_STATE_SEARCH_URL", DEFAULT_STATE_SEARCH_URL),
+)
 async def state_search(
     ctx: Context,
     file_path: Annotated[
@@ -2414,7 +2449,7 @@ async def state_search(
 
     goal_str = urllib.parse.quote(goal["goals"][0])
 
-    url = os.getenv("LEAN_STATE_SEARCH_URL", "https://premise-search.com")
+    url = os.getenv("LEAN_STATE_SEARCH_URL", DEFAULT_STATE_SEARCH_URL)
     req = urllib.request.Request(
         f"{url}/api/search?query={goal_str}&results={num_results}&rev=v4.22.0",
         headers={"User-Agent": "lean-lsp-mcp/0.1"},
@@ -2439,7 +2474,12 @@ async def state_search(
         openWorldHint=True,
     ),
 )
-@rate_limited("hammer_premise", max_requests=6, per_seconds=30)
+@rate_limited(
+    "hammer_premise",
+    max_requests=6,
+    per_seconds=30,
+    bypass=lambda: _custom_backend("LEAN_HAMMER_URL", DEFAULT_HAMMER_URL),
+)
 async def hammer_premise(
     ctx: Context,
     file_path: Annotated[
@@ -2472,7 +2512,7 @@ async def hammer_premise(
         "k": num_results,
     }
 
-    url = os.getenv("LEAN_HAMMER_URL", "http://leanpremise.net")
+    url = os.getenv("LEAN_HAMMER_URL", DEFAULT_HAMMER_URL)
     req = urllib.request.Request(
         url + "/retrieve",
         headers={

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -297,6 +297,39 @@ def test_rate_limited_trims_expired(monkeypatch: pytest.MonkeyPatch) -> None:
     assert rate_limit["test"] == [100]
 
 
+def test_rate_limited_bypass_skips_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When bypass() is true (custom backend), the limit is not applied."""
+    times = iter([100, 101, 102])
+    monkeypatch.setattr(server.time, "time", lambda: next(times))
+
+    @server.rate_limited("test", max_requests=1, per_seconds=10, bypass=lambda: True)
+    def wrapped(*, ctx: types.SimpleNamespace) -> str:
+        """Test helper"""
+        return "ok"
+
+    ctx = _make_ctx()
+    assert wrapped(ctx=ctx) == "ok"
+    assert wrapped(ctx=ctx) == "ok"
+    assert wrapped(ctx=ctx) == "ok"
+
+
+def test_custom_backend_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    default = "https://premise-search.com"
+
+    monkeypatch.delenv("LEAN_STATE_SEARCH_URL", raising=False)
+    assert server._custom_backend("LEAN_STATE_SEARCH_URL", default) is False
+
+    monkeypatch.setenv("LEAN_STATE_SEARCH_URL", default)
+    assert server._custom_backend("LEAN_STATE_SEARCH_URL", default) is False
+
+    # Trailing-slash difference should still count as the default.
+    monkeypatch.setenv("LEAN_STATE_SEARCH_URL", default + "/")
+    assert server._custom_backend("LEAN_STATE_SEARCH_URL", default) is False
+
+    monkeypatch.setenv("LEAN_STATE_SEARCH_URL", "http://localhost:8000")
+    assert server._custom_backend("LEAN_STATE_SEARCH_URL", default) is True
+
+
 def test_parse_disabled_tools() -> None:
     assert server._parse_disabled_tools(None) == set()
     assert server._parse_disabled_tools("") == set()


### PR DESCRIPTION
## Rate limits for self-hosted backends

Three search tools can be pointed at a self-hosted backend:

| Tool | Env var | Default (shared public) |
|------|---------|-------------------------|
| `lean_loogle` | `LOOGLE_URL` | `loogle.lean-lang.org` |
| `lean_state_search` | `LEAN_STATE_SEARCH_URL` | `premise-search.com` |
| `lean_hammer_premise` | `LEAN_HAMMER_URL` | `leanpremise.net` |

Rate limits exist to be a polite citizen of the **shared public** services. When a user configures their **own** (non-default) backend, the requests no longer hit those services, so the rate limit is now skipped.

- New `_custom_backend(env_var, default_url)` helper (trailing-slash-insensitive; only a *non-default* URL counts as custom).
- `rate_limited` decorator gained an optional `bypass` hook; loogle's inline limiter got the same guard.
- `lean_leansearch` and `lean_leanfinder` are hardcoded to public endpoints (no custom-backend option), so their limits are unchanged in this respect.

## Raise LeanSearch limit (3 → 90 req/30s)

Per the leansearch.net maintainers: they raised capacity (~40 req/s, per-IP ~120 req/min) and asked downstreams to lift the previously very conservative 3 req/30s. This client-side throttle mainly guards against runaway loops; the server enforces its own per-IP limit, which they adjust dynamically.

## Misc
- Centralized default URLs as constants (`DEFAULT_LOOGLE_URL`, `DEFAULT_STATE_SEARCH_URL`, `DEFAULT_HAMMER_URL`) — single source of truth.
- README documents the rate-limit skip on all three env vars.

## Tests
- `test_rate_limited_bypass_skips_limit` — bypass=true allows calls past the limit.
- `test_custom_backend_detection` — unset / default / trailing-slash / custom cases.
- Full unit suite: 249 passed / 3 skipped; ruff check + format clean.