### PR TITLE
Fix local loogle: search-path clobber and CLI flag drift (#193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ export LEAN_LOOGLE_LOCAL=true
 
 **Note:** Local loogle is currently only supported on Unix systems (Linux/macOS). Windows users should use WSL or the remote API.
 
+**Mathlib must come from your project:** loogle searches the `Mathlib` it finds on the search path, which is taken from your project's built dependencies (`.lake/packages/mathlib`). This requires `--lean-project-path` to point at a project that depends on Mathlib, has been built, and uses the same Lean toolchain as loogle. If the toolchain differs or Mathlib isn't built, local loogle falls back to the remote API.
+
 Falls back to remote API if local loogle fails.
 
 ## Notes on MCP Security

--- a/src/lean_lsp_mcp/loogle.py
+++ b/src/lean_lsp_mcp/loogle.py
@@ -90,6 +90,7 @@ class LoogleManager:
         self._ready = False
         self._lock = asyncio.Lock()
         self._extra_paths: list[Path] = []
+        self._base_lean_path: str | None = None
 
     @property
     def binary_path(self) -> Path:
@@ -116,10 +117,14 @@ class LoogleManager:
         return True, ""
 
     def _run(
-        self, cmd: list[str], timeout: int = 300, cwd: Path | None = None
+        self,
+        cmd: list[str],
+        timeout: int = 300,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess:
-        env = os.environ.copy()
-        env["LAKE_ARTIFACT_CACHE"] = "false"
+        run_env = env if env is not None else os.environ.copy()
+        run_env["LAKE_ARTIFACT_CACHE"] = "false"
         return subprocess.run(
             cmd,
             capture_output=True,
@@ -127,7 +132,7 @@ class LoogleManager:
             encoding="utf-8",
             timeout=timeout,
             cwd=cwd or self.repo_dir,
-            env=env,
+            env=run_env,
         )
 
     def _clone_repo(self) -> bool:
@@ -294,6 +299,40 @@ class LoogleManager:
             paths.append(project_lib)
         return sorted(paths)
 
+    def _get_base_lean_path(self) -> str:
+        """Loogle's own search path (toolchain core + loogle build + mathlib).
+
+        Captured via `lake env` so it includes the Lean toolchain library (where
+        `Init.olean` lives) and loogle's mathlib closure. Cached after first call.
+        """
+        if self._base_lean_path is None:
+            try:
+                r = self._run(["lake", "env", "printenv", "LEAN_PATH"], timeout=120)
+                self._base_lean_path = r.stdout.strip() if r.returncode == 0 else ""
+            except Exception as e:
+                logger.warning(f"Could not determine loogle base LEAN_PATH: {e}")
+                self._base_lean_path = ""
+        return self._base_lean_path
+
+    def _loogle_env(self) -> dict[str, str]:
+        """Subprocess environment for running the loogle binary.
+
+        Project library paths are passed via LEAN_PATH (not loogle's `--path`,
+        which *replaces* the whole search path and would drop the toolchain core,
+        causing "unknown module prefix 'Init'"). LEAN_PATH extends loogle's base
+        search path instead. With no extra paths we leave LEAN_PATH unset so
+        loogle uses its built-in compile-time search path.
+        """
+        env = os.environ.copy()
+        env["LAKE_ARTIFACT_CACHE"] = "false"
+        if self._extra_paths:
+            parts: list[str] = []
+            if base := self._get_base_lean_path():
+                parts.append(base)
+            parts.extend(str(p) for p in self._extra_paths)
+            env["LEAN_PATH"] = os.pathsep.join(parts)
+        return env
+
     def _get_index_path(self) -> Path:
         base = f"mathlib-{self._get_mathlib_version()}"
         if self._extra_paths:
@@ -332,11 +371,16 @@ class LoogleManager:
         self.index_dir.mkdir(parents=True, exist_ok=True)
         self._cleanup_old_indices()
 
-        # Build command with extra paths
-        cmd = [str(self.binary_path), "--write-index", str(index_path), "--json"]
-        for path in self._extra_paths:
-            cmd.extend(["--path", str(path)])
-        cmd.append("")  # Empty query for index building
+        # Project paths are supplied via LEAN_PATH (see _loogle_env), not --path.
+        cmd = [
+            str(self.binary_path),
+            "--index-mode",
+            "write",
+            "--index-file",
+            str(index_path),
+            "--json",
+            "",  # Empty query: just build the index and exit.
+        ]
 
         if self._extra_paths:
             logger.info(
@@ -345,7 +389,7 @@ class LoogleManager:
         else:
             logger.info("Building search index...")
         try:
-            self._run(cmd, timeout=600)
+            self._run(cmd, timeout=600, env=self._loogle_env())
             return index_path if index_path.exists() else None
         except Exception as e:
             logger.error(f"Index build error: {e}")
@@ -399,12 +443,19 @@ class LoogleManager:
                 # Build new index if paths changed
                 self._build_index()
 
-        cmd = [str(self.binary_path), "--json", "--interactive"]
-        if (idx := self._get_index_path()).exists():
-            cmd.extend(["--read-index", str(idx)])
-        # Add extra paths for runtime search (in case not all are indexed)
-        for path in self._extra_paths:
-            cmd.extend(["--path", str(path)])
+        # `use` mode loads the on-disk index if present and fresh, otherwise
+        # builds and writes it. Project paths are supplied via LEAN_PATH (see
+        # _loogle_env), never --path.
+        self.index_dir.mkdir(parents=True, exist_ok=True)
+        cmd = [
+            str(self.binary_path),
+            "--json",
+            "--interactive",
+            "--index-mode",
+            "use",
+            "--index-file",
+            str(self._get_index_path()),
+        ]
 
         if self._extra_paths:
             logger.info(f"Starting loogle with {len(self._extra_paths)} extra paths...")
@@ -417,8 +468,12 @@ class LoogleManager:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=self.repo_dir,
+                env=self._loogle_env(),
             )
-            line = await asyncio.wait_for(self.process.stdout.readline(), timeout=120)
+            # Loading a pre-built index is fast (~seconds), but if the index is
+            # missing `--index-mode use` builds it from scratch first, which
+            # over full Mathlib takes a couple of minutes. Allow for that.
+            line = await asyncio.wait_for(self.process.stdout.readline(), timeout=300)
             decoded = line.decode("utf-8", errors="replace")
             if self.READY_SIGNAL in decoded:
                 self._ready = True

--- a/tests/unit/test_loogle.py
+++ b/tests/unit/test_loogle.py
@@ -360,6 +360,88 @@ class TestLoogleManager:
         changed = mgr.set_project_path(project)
         assert not changed
 
+    # --- issue #193: search-path and CLI-flag handling ---
+
+    def test_loogle_env_no_extra_paths(self, mgr):
+        """Without project paths, LEAN_PATH is left unset (loogle uses its own)."""
+        env = mgr._loogle_env()
+        assert "LEAN_PATH" not in env
+        assert env["LAKE_ARTIFACT_CACHE"] == "false"
+
+    def test_loogle_env_with_extra_paths(self, mgr, monkeypatch):
+        """Project paths extend (not replace) loogle's base search path via LEAN_PATH."""
+        monkeypatch.setattr(mgr, "_get_base_lean_path", lambda: "/base/a:/base/b")
+        mgr._extra_paths = [Path("/proj/p1"), Path("/proj/p2")]
+        entries = mgr._loogle_env()["LEAN_PATH"].split(os.pathsep)
+        # Loogle's base (toolchain core with Init.olean + mathlib) comes first.
+        assert entries[0] == "/base/a"
+        assert entries[1] == "/base/b"
+        assert str(Path("/proj/p1")) in entries
+        assert str(Path("/proj/p2")) in entries
+
+    def test_get_base_lean_path_caches(self, mgr, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, timeout=300, cwd=None, env=None):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="/x/lib:/y/lib\n")
+
+        monkeypatch.setattr(mgr, "_run", fake_run)
+        assert mgr._get_base_lean_path() == "/x/lib:/y/lib"
+        assert mgr._get_base_lean_path() == "/x/lib:/y/lib"  # cached, no second call
+        assert len(calls) == 1
+        assert calls[0][:3] == ["lake", "env", "printenv"]
+
+    def test_build_index_uses_index_mode_not_write_index(self, mgr, monkeypatch):
+        """Index build uses the new --index-mode/--index-file flags, never --path."""
+        mgr.binary_path.parent.mkdir(parents=True)
+        mgr.binary_path.touch()
+        mgr._extra_paths = [Path("/proj/p1")]
+        monkeypatch.setattr(mgr, "_get_base_lean_path", lambda: "/base")
+        captured = {}
+
+        def fake_run(cmd, timeout=300, cwd=None, env=None):
+            captured["cmd"], captured["env"] = cmd, env
+            Path(cmd[cmd.index("--index-file") + 1]).touch()
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(mgr, "_run", fake_run)
+        assert mgr._build_index() is not None
+        cmd = captured["cmd"]
+        assert "--index-mode" in cmd and "write" in cmd and "--index-file" in cmd
+        assert "--write-index" not in cmd
+        assert "--path" not in cmd
+        assert "LEAN_PATH" in captured["env"]
+
+    @pytest.mark.asyncio
+    async def test_start_uses_index_mode_and_lean_path(self, mgr, monkeypatch):
+        """start() uses --index-mode/--index-file and LEAN_PATH, never --read-index/--path."""
+        mgr.binary_path.parent.mkdir(parents=True)
+        mgr.binary_path.touch()
+        mgr._extra_paths = [Path("/proj/p1")]
+        monkeypatch.setattr(mgr, "check_environment", lambda: (True, ""))
+        monkeypatch.setattr(mgr, "_get_base_lean_path", lambda: "/base")
+        captured = {}
+
+        async def fake_exec(*args, **kwargs):
+            captured["args"], captured["env"] = args, kwargs.get("env")
+            proc = AsyncMock()
+            proc.returncode = None
+            proc.stdout.readline = AsyncMock(
+                return_value=(mgr.READY_SIGNAL + "\n").encode()
+            )
+            return proc
+
+        monkeypatch.setattr(
+            "lean_lsp_mcp.loogle.asyncio.create_subprocess_exec", fake_exec
+        )
+        assert await mgr.start()
+        args = list(captured["args"])
+        assert "--index-mode" in args and "use" in args and "--index-file" in args
+        assert "--read-index" not in args
+        assert "--path" not in args
+        assert "LEAN_PATH" in captured["env"]
+
 
 @pytest.mark.slow
 class TestLoogleInstall:


### PR DESCRIPTION
Closes #193.

Local loogle broke after upstream loogle changed two things lean-lsp-mcp depended on.

## Bug 1 — `unknown module prefix 'Init'` (the reported crash)
loogle's `--path` **replaces** the entire search path (`Loogle.lean`: `if !opts.searchPath.isEmpty then pure opts.searchPath`). lean-lsp-mcp passed only the project's `.lake/.../lib/lean` dirs via `--path`, which dropped the Lean toolchain core (where `Init.olean` lives) → crash → silent fallback to remote.

**Fix:** stop using `--path`. Project paths are injected into `LEAN_PATH` instead, prepended with loogle's own base path (captured via `lake env printenv LEAN_PATH`, which includes the toolchain core + loogle's closure). loogle honors `LEAN_PATH` when `--path` is empty, so `Init` stays resolvable. With no project paths, `LEAN_PATH` is left unset (loogle's original behavior — no regression).

## Bug 2 — `Index build failed` (CLI flag drift)
loogle replaced `--write-index`/`--read-index` with `--index-mode`/`--index-file`; the old flags now error (`unknown long option`). Migrated to `--index-mode use --index-file <path>` (self-healing: builds+writes if missing, loads if present).

## Also
- Startup readline timeout 120s → 300s: a from-scratch Mathlib index build takes ~2 min (a pre-built index loads in seconds), so 120s spuriously timed out.

## End-to-end validation (real Mathlib @ matching toolchain v4.30.0-rc1)
- First start builds index over full Mathlib → ready in ~137s; `query("Nat.add")` → 11 real hits; 360 MB index written.
- Second start loads the index → ready in **4.3s**; same results.
- Real `LoogleManager.start()/query()/stop()` path: `query("List.map")` → `List.map`, `List.map_eq_mapTR`, `List.map_nil`.

## Note for users (README updated)
Modern loogle no longer bundles Mathlib — it searches the `Mathlib` on its search path, which comes from the **project's** built `.lake/packages/mathlib`. So local loogle requires `--lean-project-path` to point at a built, Mathlib-using project on loogle's toolchain; otherwise it falls back to remote.

## Tests
- New regression tests assert the command/env construction: project paths go to `LEAN_PATH` (not `--path`), and index build/start use `--index-mode`/`--index-file` (never `--write-index`/`--read-index`).
- 40 loogle unit tests pass; `ruff check` + `format --check` clean.