### PR TITLE
Make the server type-check clean under ty + add ty to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       - run: uv sync --extra lint
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
+      - run: uv run ty check src/
 
   test:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,15 @@ Repository = "https://github.com/oOo0oOo/lean-lsp-mcp"
 
 [project.optional-dependencies]
 yaml = ["PyYAML>=6.0"]
-lint = ["ruff>=0.2.0"]
-dev = ["ruff>=0.2.0", "pytest>=8.3", "anyio>=4.12.1", "pytest-asyncio>=0.23", "pytest-timeout>=2.3"]
+lint = ["ruff>=0.2.0", "ty>=0.0.46"]
+dev = ["ruff>=0.2.0", "ty>=0.0.46", "pytest>=8.3", "anyio>=4.12.1", "pytest-asyncio>=0.23", "pytest-timeout>=2.3"]
+
+[tool.ty.environment]
+python-version = "3.10"
+
+[tool.ty.src]
+# The MCP server package; tests are mock-heavy and intentionally not type-checked.
+include = ["src"]
 
 [tool.ruff]
 exclude = [

--- a/src/lean_lsp_mcp/client_utils.py
+++ b/src/lean_lsp_mcp/client_utils.py
@@ -111,7 +111,7 @@ def _start_client(project_path: Path) -> LeanLSPClient:
     try:
         with OutputCapture() as output:
             client = LeanLSPClient(
-                project_path,
+                project_path,  # ty: ignore[invalid-argument-type]
                 initial_build=False,
                 prevent_cache_get=prevent_cache,
                 max_opened_files=_max_opened_files(),

--- a/src/lean_lsp_mcp/loogle.py
+++ b/src/lean_lsp_mcp/loogle.py
@@ -470,6 +470,7 @@ class LoogleManager:
                 cwd=self.repo_dir,
                 env=self._loogle_env(),
             )
+            assert self.process.stdout is not None and self.process.stderr is not None
             # Loading a pre-built index is fast (~seconds), but if the index is
             # missing `--index-mode use` builds it from scratch first, which
             # over full Mathlib takes a couple of minutes. Allow for that.
@@ -515,6 +516,8 @@ class LoogleManager:
                         raise RuntimeError("Failed to start loogle")
                     continue
 
+                assert self.process.stdin is not None
+                assert self.process.stdout is not None
                 try:
                     self.process.stdin.write(f"{q}\n".encode())
                     await self.process.stdin.drain()

--- a/src/lean_lsp_mcp/outline_utils.py
+++ b/src/lean_lsp_mcp/outline_utils.py
@@ -22,7 +22,7 @@ def _get_info_trees(
     for i, sym in enumerate(sorted(symbols, key=lambda s: s["range"]["start"]["line"])):
         line = sym["range"]["start"]["line"] + i
         symbol_by_line[line] = sym["name"]
-        changes.append(DocumentContentChange("#info_trees in\n", [line, 0], [line, 0]))
+        changes.append(DocumentContentChange("#info_trees in\n", (line, 0), (line, 0)))
 
     client.update_file(path, changes)
     diagnostics = client.get_diagnostics(path)
@@ -37,7 +37,7 @@ def _get_info_trees(
     client.update_file(
         path,
         [
-            DocumentContentChange("", [line, 0], [line + 1, 0])
+            DocumentContentChange("", (line, 0), (line + 1, 0))
             for line in sorted(symbol_by_line.keys(), reverse=True)
         ],
     )

--- a/src/lean_lsp_mcp/repl.py
+++ b/src/lean_lsp_mcp/repl.py
@@ -262,5 +262,6 @@ class Repl:
             await asyncio.wait_for(proc.wait(), timeout=1.0)
         except asyncio.TimeoutError:
             pass
-        if hasattr(proc, "_transport") and proc._transport:
-            proc._transport.close()
+        transport = getattr(proc, "_transport", None)
+        if transport is not None:
+            transport.close()

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -7,12 +7,12 @@ import os
 import re
 import ssl
 import time
-import urllib
-from collections.abc import AsyncIterator, Awaitable, Callable
+import urllib.request
+from collections.abc import AsyncIterator, Callable, Coroutine, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, NoReturn, Optional, cast
 
 import certifi
 import orjson
@@ -49,6 +49,7 @@ from lean_lsp_mcp.models import (
     # Wrapper models for list-returning tools
     DiagnosticsResult,
     MultiAttemptResult,
+    GoalContextEntry,
     StructuredGoal,
 )
 
@@ -72,7 +73,7 @@ _INSTRUCTIONS_ENV = "LEAN_MCP_INSTRUCTIONS"
 _TOOL_DESCRIPTIONS_ENV = "LEAN_MCP_TOOL_DESCRIPTIONS"
 
 
-def _raise_invalid_path(file_path: str) -> None:
+def _raise_invalid_path(file_path: str) -> NoReturn:
     """Raise a descriptive error when a file can't be resolved to a Lean project."""
     raise LeanToolError(
         f"Invalid Lean file path: '{file_path}' not found in any Lean project "
@@ -172,7 +173,7 @@ _LOG_LEVEL = config.log_level()
 if _LOG_FILE_CONFIG:
     try:
         if _LOG_FILE_CONFIG.endswith((".yaml", ".yml")):
-            import yaml
+            import yaml  # ty: ignore[unresolved-import]
 
             with open(_LOG_FILE_CONFIG, "r", encoding="utf-8") as f:
                 cfg = yaml.safe_load(f)
@@ -187,7 +188,7 @@ if _LOG_FILE_CONFIG:
     except Exception as e:
         # fallback to LEAN_LOG_LEVEL so server still runs
         # use the existing configure_logging helper to set level
-        configure_logging("CRITICAL" if _LOG_LEVEL == "NONE" else _LOG_LEVEL)
+        configure_logging(cast(Any, "CRITICAL" if _LOG_LEVEL == "NONE" else _LOG_LEVEL))
         logger = get_logger(__name__)  # temporary to emit the warning
         logger.warning(
             "Failed to load logging config %s: %s. Falling back to LEAN_LOG_LEVEL.",
@@ -195,7 +196,7 @@ if _LOG_FILE_CONFIG:
             e,
         )
 else:
-    configure_logging("CRITICAL" if _LOG_LEVEL == "NONE" else _LOG_LEVEL)
+    configure_logging(cast(Any, "CRITICAL" if _LOG_LEVEL == "NONE" else _LOG_LEVEL))
 
 logger = get_logger(__name__)
 
@@ -210,7 +211,7 @@ class BuildCoordinator:
         self._current_task: asyncio.Task[BuildResult] | None = None
 
     async def run(
-        self, build_factory: Callable[[], Awaitable[BuildResult]]
+        self, build_factory: Callable[[], Coroutine[Any, Any, BuildResult]]
     ) -> BuildResult:
         if self.mode == "allow":
             return await build_factory()
@@ -393,7 +394,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
                 logger.exception("REPL close failed during app_lifespan teardown")
 
 
-mcp_kwargs = dict(
+mcp_kwargs: dict[str, Any] = dict(
     name="Lean LSP",
     instructions=INSTRUCTIONS,
     dependencies=["leanclient"],
@@ -403,8 +404,8 @@ mcp_kwargs = dict(
 auth_token = config.auth_token()
 if auth_token:
     mcp_kwargs["auth"] = AuthSettings(
-        issuer_url="http://localhost/dummy-issuer",
-        resource_server_url="http://localhost/dummy-resource",
+        issuer_url=cast(Any, "http://localhost/dummy-issuer"),
+        resource_server_url=cast(Any, "http://localhost/dummy-resource"),
     )
     mcp_kwargs["token_verifier"] = PreSharedTokenVerifier(auth_token)
 
@@ -625,7 +626,7 @@ async def _run_build(
         # Start LSP client (without initial build since we just did it)
         with OutputCapture():
             client = LeanLSPClient(
-                lean_project_path_obj,
+                lean_project_path_obj,  # ty: ignore[invalid-argument-type]
                 initial_build=False,
                 prevent_cache_get=True,
                 max_opened_files=_max_opened_files(),
@@ -663,7 +664,7 @@ async def _run_build(
                 set_build_in_progress(lean_project_path_obj, False)
 
 
-def _to_diagnostic_messages(diagnostics: List[Dict]) -> List[DiagnosticMessage]:
+def _to_diagnostic_messages(diagnostics: Iterable[Dict]) -> List[DiagnosticMessage]:
     """Convert LSP diagnostics to DiagnosticMessage models."""
     result = []
     for diag in diagnostics:
@@ -759,7 +760,7 @@ def _goal_to_structured(goal_str: str) -> StructuredGoal:
 
     before, after = goal_str.split("⊢", 1)
 
-    context = []
+    context: list[GoalContextEntry] = []
     lines = before.splitlines()
 
     current_name = None
@@ -769,12 +770,10 @@ def _goal_to_structured(goal_str: str) -> StructuredGoal:
         nonlocal current_name, current_type_lines
         if current_name is not None:
             context.append(
-                {
-                    "name": current_name,
-                    "type": " ".join(
-                        line.strip() for line in current_type_lines
-                    ).strip(),
-                }
+                GoalContextEntry(
+                    name=current_name,
+                    type=" ".join(line.strip() for line in current_type_lines).strip(),
+                )
             )
         current_name = None
         current_type_lines = []
@@ -898,7 +897,7 @@ def _shift_baseline_keys(
 
 
 def _filter_diagnostics_by_line_range(
-    diagnostics: List[Dict], start_line: int, end_line: int
+    diagnostics: Iterable[Dict], start_line: int, end_line: int
 ) -> List[Dict]:
     """Return diagnostics that intersect the requested 0-indexed line range."""
     matches: List[Dict] = []
@@ -946,8 +945,8 @@ def _prepare_multi_attempt_edit(
     line_delta = len(payload_lines) - (end_line - (line - 1))
     change = DocumentContentChange(
         payload,
-        [line - 1, target_column],
-        [end_line, 0],
+        (line - 1, target_column),
+        (end_line, 0),
     )
 
     goal_line = line - 1 + len(payload_lines) - 1

--- a/src/lean_lsp_mcp/tools/analysis.py
+++ b/src/lean_lsp_mcp/tools/analysis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import uuid
+from collections.abc import Iterable
 from typing import Annotated, Dict, List, Optional
 
 from leanclient import DocumentContentChange, LeanLSPClient
@@ -96,7 +97,7 @@ def run_code(
         raise server.LeanToolError(f"Error writing code snippet: {e}")
 
     client: LeanLSPClient | None = lifespan_context.client
-    raw_diagnostics: List[Dict] = []
+    raw_diagnostics: Iterable[Dict] = []
     opened_file = False
 
     try:
@@ -190,8 +191,8 @@ def verify_theorem(
     try:
         change = DocumentContentChange(
             snippet,
-            [appended_line, 0],
-            [appended_line, 0],
+            (appended_line, 0),
+            (appended_line, 0),
         )
         client.update_file(rel_path, [change])
         raw = client.get_diagnostics(
@@ -223,7 +224,7 @@ def verify_theorem(
     if scan_source:
         if server._RG_AVAILABLE:
             w = [
-                SourceWarning(line=w["line"], pattern=w["pattern"])
+                SourceWarning(line=int(w["line"]), pattern=str(w["pattern"]))
                 for w in scan_warnings(abs_path)
             ]
         else:

--- a/src/lean_lsp_mcp/tools/goals.py
+++ b/src/lean_lsp_mcp/tools/goals.py
@@ -10,7 +10,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from lean_lsp_mcp import server
-from lean_lsp_mcp.models import GoalState, TermGoalState
+from lean_lsp_mcp.models import GoalState, StructuredGoal, TermGoalState
 
 
 @server.mcp.tool(
@@ -66,12 +66,15 @@ def goal(
         goal_start = server._get_goal_response(client, rel_path, line - 1, column_start)
         server.check_lsp_response(goal_start, "get_goal", allow_none=True)
         goal_end = server._get_goal_response(client, rel_path, line - 1, column_end)
-        goals_before = server.extract_goals_list(goal_start)
-        goals_after = server.extract_goals_list(goal_end)
-
-        if format == "structured":
-            goals_before = [server._goal_to_structured(g) for g in goals_before]
-            goals_after = [server._goal_to_structured(g) for g in goals_after]
+        structured = format == "structured"
+        goals_before: list[str | StructuredGoal] = [
+            server._goal_to_structured(g) if structured else g
+            for g in server.extract_goals_list(goal_start)
+        ]
+        goals_after: list[str | StructuredGoal] = [
+            server._goal_to_structured(g) if structured else g
+            for g in server.extract_goals_list(goal_end)
+        ]
 
         return GoalState(
             line_context=line_context,
@@ -81,9 +84,11 @@ def goal(
     else:
         goal_result = server._get_goal_response(client, rel_path, line - 1, column - 1)
         server.check_lsp_response(goal_result, "get_goal", allow_none=True)
-        goals = server.extract_goals_list(goal_result)
-        if format == "structured":
-            goals = [server._goal_to_structured(g) for g in goals]
+        structured = format == "structured"
+        goals: list[str | StructuredGoal] = [
+            server._goal_to_structured(g) if structured else g
+            for g in server.extract_goals_list(goal_result)
+        ]
         return GoalState(
             line_context=line_context,
             goals=goals,

--- a/src/lean_lsp_mcp/utils.py
+++ b/src/lean_lsp_mcp/utils.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import os
 import re
 import secrets
 import sys
 import tempfile
+from collections.abc import Iterable
 from typing import Any, List, Dict, Optional, Callable
 
 from mcp.server.auth.provider import AccessToken, TokenVerifier
@@ -189,7 +192,7 @@ def _utf16_index_to_py_index(text: str, utf16_index: int) -> int | None:
     return None
 
 
-def extract_range(content: str, range: dict) -> str:
+def extract_range(content: str, range: dict | None) -> str:
     """Extract the text from the content based on the range.
 
     Args:
@@ -199,6 +202,8 @@ def extract_range(content: str, range: dict) -> str:
     Returns:
         str: The extracted range text.
     """
+    if not range:
+        return ""
     start_line = range["start"]["line"]
     start_char = range["start"]["character"]
     end_line = range["end"]["line"]
@@ -285,7 +290,7 @@ def format_line(
 
 
 def filter_diagnostics_by_position(
-    diagnostics: List[Dict], line: Optional[int], column: Optional[int]
+    diagnostics: Iterable[Dict], line: Optional[int], column: Optional[int]
 ) -> List[Dict]:
     """Return diagnostics that intersect the requested (0-indexed) position."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -345,9 +345,11 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 lint = [
     { name = "ruff" },
+    { name = "ty" },
 ]
 yaml = [
     { name = "pyyaml" },
@@ -366,6 +368,8 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.2.0" },
+    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.46" },
+    { name = "ty", marker = "extra == 'lint'", specifier = ">=0.0.46" },
 ]
 provides-extras = ["yaml", "lint", "dev"]
 
@@ -1165,6 +1169,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.46"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/7d/d95b5a9dea83472006be3ce5e480028c44b34138d84d0172e910f287fb69/ty-0.0.46.tar.gz", hash = "sha256:c6c2d7105b5633b49950b4c3a90d1ed2613eb9d794ad582bbbf6c4ffcb93accf", size = 5832380, upload-time = "2026-06-09T03:28:05.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/24/f9f7533c391610521f4164e6b8e37ef72d0c1ee8651bc0d9ce9e658b953b/ty-0.0.46-py3-none-linux_armv6l.whl", hash = "sha256:5e716337994699cbc1a1a7b7a3e6622306f2574c710330f9d9691c2c3d8391b0", size = 11756264, upload-time = "2026-06-09T03:28:20.112Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/ff3d13655b9b5cc8176f4c3446bf7ec2df43c8ad9e5272d4adc5d952fa45/ty-0.0.46-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:51d618dec5403635690d0e3e298cd0ad3d84ebc6a576652939ef30ce96fce4b2", size = 11492723, upload-time = "2026-06-09T03:28:13.23Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4a/e7e3209e353c5835c7756339bbcdfda10852407b80fbb9ed46c17241873a/ty-0.0.46-py3-none-macosx_11_0_arm64.whl", hash = "sha256:acbafd6a2351b07a6cf4c945b0b1d47f6d2826faac2526a351dfa74d3a3cc664", size = 10892822, upload-time = "2026-06-09T03:27:51.179Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/20/4390c90434a9ddefcecb65e8df00e4c2700e9739dc0baf58bed36d25f713/ty-0.0.46-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de5df602ffd760612ae36602bbad69b0123ff6cffd92e62aa92b7709317d69e3", size = 11408745, upload-time = "2026-06-09T03:27:58.049Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0c/f13a1bf9c6798530c773667095a6cf8f73ec9721db359423e7249bff7fbc/ty-0.0.46-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7abf5a10b30d8641faad90f6a19989daec941bb90261159e05cfeb04d2012046", size = 11544432, upload-time = "2026-06-09T03:27:53.519Z" },
+    { url = "https://files.pythonhosted.org/packages/56/69/eb3710c13dff846a0362df04fadd8a39b64ccc244c0d02ce5285ede8eae5/ty-0.0.46-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8770404139c6ccee2ce2fc226478cfa4100915133c876c257e52197b8b92051d", size = 12031228, upload-time = "2026-06-09T03:28:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/68/5f5db9c84c1d44acdc67281089b372d9d818ee68123a60c59c66187095e2/ty-0.0.46-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f960d5a6e4860076924d2b86891d9872c4a3daa4663fb416e640b22cf3dbf68e", size = 12596073, upload-time = "2026-06-09T03:28:25.204Z" },
+    { url = "https://files.pythonhosted.org/packages/14/be/cfd0bb272e6a1491f6de30c60da1f39c2b3c3524ec64a5c92b71365c9185/ty-0.0.46-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1d9000a4a3ed08fc37e8a2ff0b801cde06e1c2af3bc053677744bb5a1b751030", size = 12284885, upload-time = "2026-06-09T03:28:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/2cd541f6320f5d6f70a45725c4e1016efedd5545348bb23b47ffb3e4c724/ty-0.0.46-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1160e6dc86536109ab755f7142f36f4dda5333c8330cf230d61819494d27125", size = 12079480, upload-time = "2026-06-09T03:27:55.847Z" },
+    { url = "https://files.pythonhosted.org/packages/de/91/8e0075bc6568fb477e7ef4d805c67fa6902b692cb4419e0bf5ce3c04c5bc/ty-0.0.46-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b619c0efe007731f8221fa787701bfa4402da7a83eb26c61ae25e77b6ace6384", size = 12316547, upload-time = "2026-06-09T03:28:08.28Z" },
+    { url = "https://files.pythonhosted.org/packages/00/28/b96cbfeda019a4044c6a8cd06ff84d08b631d4ba7d9a1e6dc0311df3563a/ty-0.0.46-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ad98fccb6a8a94c4121b993761a0deee602f5826c4162e0a91f4f8118ddadd42", size = 11392846, upload-time = "2026-06-09T03:28:00.418Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d0/4d77f699a95ac7a13b94ca1a58682667cfe974f91557d9e2a9fc0b808a7f/ty-0.0.46-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:74536b13c3cc3f5944408669c202d4c57c3d19ff154732df8e6145718aef9191", size = 11559017, upload-time = "2026-06-09T03:28:17.619Z" },
+    { url = "https://files.pythonhosted.org/packages/88/62/1d6f6b51c2b132da8011c6a41ead0c1fd2a0b17ea72304bcf6ce084d581a/ty-0.0.46-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5e50b1e96ced41b609e24ed27d9e4f508584ed7f4d0bb717ca8c8d75d2fd1b7c", size = 11666509, upload-time = "2026-06-09T03:28:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9a/6643894bc12cb30c281f4c8bf37f6d30c1fbd9484ef39a12b0ea6dae3c1c/ty-0.0.46-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0a7d9f58d26d938e5d2f607481b7a412d8c00d675a1ec72004fa9d6b3b9def99", size = 12180448, upload-time = "2026-06-09T03:28:32.329Z" },
+    { url = "https://files.pythonhosted.org/packages/86/68/0f3b7bb03a7da676ef51b1c0af0bde1e500d69d5f0c807ed63b6f30b66dd/ty-0.0.46-py3-none-win32.whl", hash = "sha256:26db0ce89c573e60132d14e9688c9329a1633b1a8c26fe457025c7c406f7d5e6", size = 10960002, upload-time = "2026-06-09T03:28:02.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f4/91ff618b2dee39d0633d23e1adac0174aa1de80df17e270acac534034dbc/ty-0.0.46-py3-none-win_amd64.whl", hash = "sha256:90e8e6d446b9cb7cb4bede9fca7b3c99fd1e2355605ecf431c131a51db2a5e93", size = 12097413, upload-time = "2026-06-09T03:28:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2e/300174fca375a27a7c28dd80e990d857d7b3e3b25980c65063f980aa2f17/ty-0.0.46-py3-none-win_arm64.whl", hash = "sha256:ebd320d82605079b901a095dc4711037a0c488b4ace79a602fef4df0d3f4cf74", size = 11439595, upload-time = "2026-06-09T03:28:15.355Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Makes the MCP server (`src/`) pass Astral's `ty` type checker (**119 → 0** diagnostics) and adds `ty check src/` to the lint CI job. **No runtime behavior or MCP API change** — full unit suite green (265 passed).

## Highlights
- **`_raise_invalid_path -> NoReturn`** — lets `str | None` paths narrow to `str` after the `if not rel_path:` guard, clearing ~half the diagnostics in one line.
- **`mcp_kwargs: dict[str, Any]`** — fixes ~20 `**kwargs`/assignment errors.
- Widened diagnostic-consuming helpers to `Iterable[Dict]` (leanclient `DiagnosticsResult` is list-like: implements `__iter__/__len__/__getitem__`).
- Tuple positions for `DocumentContentChange`; built `GoalState` lists + `GoalContextEntry` with correct element types; `from __future__ import annotations` in utils; asserts where PIPE/readiness invariants hold; `str→int/str` coercions matching declared types.
- A few **targeted `# ty: ignore`** for genuine third-party strictness: optional `yaml` import, and `leanclient.__init__` (accepts `PathLike` at runtime, typed `str` in the installed release — can drop once the typed leanclient ships).

## CI / config
- `ty>=0.0.46` added to the `lint` and `dev` extras (locked in `uv.lock`).
- `[tool.ty]`: `python-version = "3.10"`, and `src.include = ["src"]` so checks scope to the package.
- New CI step: `uv run ty check src/` in the lint job.

## Scope note
`tests/` are **not** type-checked (mock-heavy: ~66 `MagicMock`/`AsyncMock` false-positives that would need low-value churn or ignores). The config scopes `ty` to `src/` — the actual server. Happy to tackle tests separately if wanted.