### PR TITLE
Fix release blockers: wheel packaging (tools/) + minimal_hypotheses no-binder case

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,10 @@ asyncio_mode = "auto"
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 
 [tool.setuptools]
-packages = ["lean_lsp_mcp"]
 package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/src/lean_lsp_mcp/minimal_hypotheses.py
+++ b/src/lean_lsp_mcp/minimal_hypotheses.py
@@ -27,6 +27,18 @@ def _find_balanced_close(s: str, open_pos: int, open_ch: str, close_ch: str) -> 
     return -1
 
 
+def theorem_declared(source: str, name: str) -> bool:
+    """True if `source` declares a theorem/lemma/example/def named `name`.
+
+    Lets callers distinguish a genuinely-missing theorem from one that simply
+    has no binders (``find_theorem_binders`` returns ``[]`` for both).
+    """
+    return (
+        re.search(rf"\b(theorem|lemma|example|def)\s+{re.escape(name)}\b", source)
+        is not None
+    )
+
+
 def find_theorem_binders(source: str, name: str) -> list[tuple[str, int, int]]:
     """Find the binder list of a theorem/lemma/def.
 

--- a/src/lean_lsp_mcp/tools/analysis.py
+++ b/src/lean_lsp_mcp/tools/analysis.py
@@ -281,6 +281,7 @@ def minimal_hypotheses(
         drop_binder,
         explicit_hypotheses,
         find_theorem_binders,
+        theorem_declared,
     )
 
     theorem_name = server._validate_theorem_name(theorem_name)
@@ -304,15 +305,17 @@ def minimal_hypotheses(
         raise server.LeanToolError(f"Could not read content for {rel_path}")
 
     bare_name = theorem_name.split(".")[-1]
-    binders = find_theorem_binders(original_content, bare_name)
-    if not binders:
+    if not theorem_declared(original_content, bare_name):
         raise server.LeanToolError(
-            f"Could not find theorem '{theorem_name}' in {rel_path}, "
-            "or it has no binders before its type."
+            f"Could not find theorem '{theorem_name}' in {rel_path}."
         )
+
+    binders = find_theorem_binders(original_content, bare_name)
     explicit = explicit_hypotheses(binders)
     skipped = len(binders) - len(explicit)
 
+    # Theorem found but nothing explicit to probe (no binders, or only
+    # implicit/instance binders): there is no hypothesis to minimize.
     if not explicit:
         return MinimalHypothesesResult(
             theorem_name=theorem_name,


### PR DESCRIPTION
Two issues surfaced by the **slow** test suite (which isn't in CI), both fixed here.

## 1. Packaging blocker (critical) 🔴
`[tool.setuptools] packages = ["lean_lsp_mcp"]` excluded the new `lean_lsp_mcp.tools` subpackage from the **built wheel** — the published package would `ModuleNotFoundError: No module named 'lean_lsp_mcp.tools'` on every tool. (Introduced by the modular-architecture refactor; only the nix-flake/wheel test catches it.)

**Fix:** switched to `[tool.setuptools.packages.find] where = ["src"]` (auto-discovers subpackages, future-proof). Verified the wheel now contains `lean_lsp_mcp/tools/*`, imports cleanly, and **the nix-flake test passes**.

## 2. `lean_minimal_hypotheses` no-binder case
The tool raised `Could not find theorem '...' or it has no binders` for a theorem that *exists* but has no explicit hypotheses (e.g. `theorem t : True := trivial`), instead of returning an empty result. Added `theorem_declared()` to distinguish a genuinely-missing theorem (still errors) from a found-but-no-explicit-binder one (empty result). Fixes `test_minimal_hypotheses_no_explicit`.

## Verification
- `uv build` wheel includes `tools/`; clean-venv install runs `lean-lsp-mcp --version`; nix-flake slow test passes.
- `ty check src/` clean, ruff clean, unit suite green, `no_explicit` passes.

## Known, NOT a blocker
`test_minimal_hypotheses_skips_implicit_and_instance` still fails — but it fails on **leanclient 0.10.0 too** (pre-existing, not from the dep bump or refactor). Root cause is the Lean **LSP file-worker terminating** (-32801) when dropping a load-bearing hypothesis makes the body ill-typed, so the tool sees no diagnostics and reports a false `removable`. It's a slow/non-CI test and environment-dependent. Recommend a separate follow-up (tool robustness against terminated-worker responses) — out of scope for the release blockers.