### PR TITLE
(fix) concurrency: serialize shared LSP file operations

### DIFF
--- a/src/lean_lsp_mcp/client_utils.py
+++ b/src/lean_lsp_mcp/client_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -298,6 +299,52 @@ def _close_client(client: LeanLSPClient, message: str) -> None:
         logger.exception(message)
 
 
+def _is_file_worker_shutdown(exc: BaseException) -> bool:
+    message = str(exc)
+    return (
+        "LSP Error:" in message
+        and "-32801" in message
+        and "file worker" in message
+        and "terminated" in message
+    )
+
+
+def _drain_wait_for_diagnostics_failure(future) -> None:
+    try:
+        exc = future.exception()
+    except asyncio.CancelledError:
+        return
+    except Exception:
+        logger.debug("Failed to inspect waitForDiagnostics future", exc_info=True)
+        return
+
+    if exc is None:
+        return
+
+    if _is_file_worker_shutdown(exc):
+        logger.debug("Ignored stale waitForDiagnostics response: %s", exc)
+    else:
+        logger.warning("waitForDiagnostics returned an error: %s", exc)
+
+
+def _install_wait_for_diagnostics_drain(client: LeanLSPClient) -> None:
+    if getattr(client, "_lean_lsp_mcp_wait_diag_drain", False):
+        return
+
+    send_request_async = getattr(client, "_send_request_async", None)
+    if not callable(send_request_async):
+        return
+
+    def _send_request_async(method: str, params: dict):
+        future = send_request_async(method, params)
+        if method == "textDocument/waitForDiagnostics":
+            future.add_done_callback(_drain_wait_for_diagnostics_failure)
+        return future
+
+    setattr(client, "_send_request_async", _send_request_async)
+    setattr(client, "_lean_lsp_mcp_wait_diag_drain", True)
+
+
 def bind_lean_project_path(ctx: Context, project_path: Path | str) -> Path:
     with _routing_lock(ctx):
         lifespan = ctx.request_context.lifespan_context
@@ -347,6 +394,7 @@ def _start_client(project_path: Path) -> LeanLSPClient:
                 prevent_cache_get=prevent_cache,
                 max_opened_files=_max_opened_files(),
             )
+            _install_wait_for_diagnostics_drain(client)
             logger.info("Shared LSP client connected at %s", project_path)
         build_output = output.get_output()
         if build_output:

--- a/src/lean_lsp_mcp/client_utils.py
+++ b/src/lean_lsp_mcp/client_utils.py
@@ -58,13 +58,19 @@ def _routing_lock(ctx: Context):
 
 
 def _set_lifespan_client_if_current(ctx: Context, op: LspClientOperation) -> None:
+    set_lifespan_client_for_project(ctx, op.project_path, op.client)
+
+
+def set_lifespan_client_for_project(
+    ctx: Context, project_path: Path | str, client: LeanLSPClient | None
+) -> None:
     with _routing_lock(ctx):
         lifespan = ctx.request_context.lifespan_context
         current_root: Path | None = getattr(lifespan, "lean_project_path", None)
         if current_root is not None:
             current_root = current_root.resolve(strict=False)
-        if current_root == op.project_path:
-            lifespan.client = op.client
+        if current_root == _project_key(project_path):
+            lifespan.client = client
 
 
 class ProjectRuntime:
@@ -73,7 +79,7 @@ class ProjectRuntime:
         self._client: LeanLSPClient | None = None
         self._lock = RLock()
         self._condition = Condition(self._lock)
-        self._active_operations = 0
+        self._operation_active = False
         self._build_in_progress = False
         self._registry_reservations = 0
 
@@ -96,19 +102,19 @@ class ProjectRuntime:
 
     def _acquire_operation(self) -> LeanLSPClient:
         with self._condition:
-            while self._active_operations:
+            while self._operation_active:
                 self._condition.wait()
             if self._build_in_progress:
                 raise ValueError(
                     "A project build is in progress. Retry after the build completes."
                 )
             client = self._start_or_reuse_client()
-            self._active_operations = 1
+            self._operation_active = True
             return client
 
     def _release_operation(self) -> None:
         with self._condition:
-            self._active_operations = 0
+            self._operation_active = False
             self._condition.notify_all()
         with _RUNTIME_AVAILABLE:
             _RUNTIME_AVAILABLE.notify_all()
@@ -154,7 +160,7 @@ class ProjectRuntime:
                 raise ValueError(
                     "A project build is already in progress. Retry after the build completes."
                 )
-            while self._active_operations:
+            while self._operation_active:
                 self._condition.wait()
             self._build_in_progress = True
             client = self._client
@@ -184,7 +190,7 @@ class ProjectRuntime:
         try:
             return (
                 not self._build_in_progress
-                and self._active_operations == 0
+                and not self._operation_active
                 and self._registry_reservations == 0
             )
         finally:

--- a/src/lean_lsp_mcp/client_utils.py
+++ b/src/lean_lsp_mcp/client_utils.py
@@ -1,5 +1,8 @@
 from pathlib import Path
-from threading import Lock
+from contextlib import contextmanager
+from dataclasses import dataclass
+from threading import Condition, RLock
+from typing import Iterator
 
 from leanclient import LeanLSPClient
 from mcp.server.fastmcp import Context
@@ -17,12 +20,232 @@ from lean_lsp_mcp import config
 
 
 logger = get_logger(__name__)
-CLIENT_LOCK = Lock()
-_shared_clients: dict[Path, LeanLSPClient] = {}
-_builds_in_progress: set[Path] = set()
+CLIENT_LOCK = RLock()
+_RUNTIME_AVAILABLE = Condition(CLIENT_LOCK)
+_project_runtimes: dict[Path, "ProjectRuntime"] = {}
 
 
 _MAX_SHARED_CLIENTS = 8
+
+
+class InvalidLeanFilePathError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class LspClientOperation:
+    client: LeanLSPClient
+    project_path: Path
+
+
+@dataclass(frozen=True)
+class LspFileOperation(LspClientOperation):
+    path_policy: LeanPathPolicy
+    rel_path: str
+
+
+def _project_key(project_path: Path | str) -> Path:
+    return Path(project_path).resolve(strict=False)
+
+
+def _routing_lock(ctx: Context):
+    lifespan = ctx.request_context.lifespan_context
+    lock = getattr(lifespan, "routing_lock", None)
+    if lock is None:
+        lock = RLock()
+        lifespan.routing_lock = lock
+    return lock
+
+
+def _set_lifespan_client_if_current(ctx: Context, op: LspClientOperation) -> None:
+    with _routing_lock(ctx):
+        lifespan = ctx.request_context.lifespan_context
+        current_root: Path | None = getattr(lifespan, "lean_project_path", None)
+        if current_root is not None:
+            current_root = current_root.resolve(strict=False)
+        if current_root == op.project_path:
+            lifespan.client = op.client
+
+
+class ProjectRuntime:
+    def __init__(self, project_path: Path | str) -> None:
+        self.project_path = _project_key(project_path)
+        self._client: LeanLSPClient | None = None
+        self._lock = RLock()
+        self._condition = Condition(self._lock)
+        self._active_operations = 0
+        self._build_in_progress = False
+        self._registry_reservations = 0
+
+    def _start_or_reuse_client(self) -> LeanLSPClient:
+        if self._build_in_progress:
+            raise ValueError(
+                "A project build is in progress. Retry after the build completes."
+            )
+
+        client = self._client
+        if client is not None and _client_is_alive(client):
+            return client
+
+        if client is not None:
+            self._client = None
+            _close_client(client, "Shared Lean client close failed during restart")
+
+        self._client = _start_client(self.project_path)
+        return self._client
+
+    def _acquire_operation(self) -> LeanLSPClient:
+        with self._condition:
+            while self._active_operations:
+                self._condition.wait()
+            if self._build_in_progress:
+                raise ValueError(
+                    "A project build is in progress. Retry after the build completes."
+                )
+            client = self._start_or_reuse_client()
+            self._active_operations = 1
+            return client
+
+    def _release_operation(self) -> None:
+        with self._condition:
+            self._active_operations = 0
+            self._condition.notify_all()
+        with _RUNTIME_AVAILABLE:
+            _RUNTIME_AVAILABLE.notify_all()
+
+    def _reserve_for_registry(self) -> None:
+        with self._condition:
+            self._registry_reservations += 1
+
+    def _release_registry_reservation(self) -> None:
+        with self._condition:
+            self._registry_reservations -= 1
+            self._condition.notify_all()
+        with _RUNTIME_AVAILABLE:
+            _RUNTIME_AVAILABLE.notify_all()
+
+    @contextmanager
+    def operation(self) -> Iterator[LspClientOperation]:
+        client = self._acquire_operation()
+        try:
+            yield LspClientOperation(client=client, project_path=self.project_path)
+        finally:
+            self._release_operation()
+
+    @contextmanager
+    def file_operation(
+        self, path_policy: LeanPathPolicy, rel_path: str
+    ) -> Iterator[LspFileOperation]:
+        client = self._acquire_operation()
+        try:
+            client.open_file(rel_path)
+            yield LspFileOperation(
+                client=client,
+                project_path=self.project_path,
+                path_policy=path_policy,
+                rel_path=rel_path,
+            )
+        finally:
+            self._release_operation()
+
+    def detach_for_build(self) -> None:
+        with self._condition:
+            if self._build_in_progress:
+                raise ValueError(
+                    "A project build is already in progress. Retry after the build completes."
+                )
+            while self._active_operations:
+                self._condition.wait()
+            self._build_in_progress = True
+            client = self._client
+            self._client = None
+        if client is not None:
+            _close_client(client, "Lean client close failed during lsp_build restart")
+
+    def install_restarted_client(self, client: LeanLSPClient) -> None:
+        with self._condition:
+            old_client = self._client
+            self._client = client
+            self._build_in_progress = False
+            self._condition.notify_all()
+        if old_client is not None and old_client is not client:
+            _close_client(old_client, "Replaced Lean client close failed")
+
+    def clear_build_in_progress(self) -> None:
+        with self._condition:
+            self._build_in_progress = False
+            self._condition.notify_all()
+        with _RUNTIME_AVAILABLE:
+            _RUNTIME_AVAILABLE.notify_all()
+
+    def can_evict(self) -> bool:
+        if not self._lock.acquire(blocking=False):
+            return False
+        try:
+            return (
+                not self._build_in_progress
+                and self._active_operations == 0
+                and self._registry_reservations == 0
+            )
+        finally:
+            self._lock.release()
+
+    def close(self) -> None:
+        with self._condition:
+            client = self._client
+            self._client = None
+            self._build_in_progress = False
+            self._condition.notify_all()
+        if client is not None:
+            _close_client(client, "Shared Lean client close failed during shutdown")
+        with _RUNTIME_AVAILABLE:
+            _RUNTIME_AVAILABLE.notify_all()
+
+
+def _select_project_runtime(
+    project_path: Path | str, *, reserve: bool = False
+) -> ProjectRuntime:
+    project_key = _project_key(project_path)
+    evicted_runtime: ProjectRuntime | None = None
+    with CLIENT_LOCK:
+        runtime = _project_runtimes.pop(project_key, None)
+        if runtime is not None:
+            _project_runtimes[project_key] = runtime
+            if reserve:
+                runtime._reserve_for_registry()
+            return runtime
+
+        while len(_project_runtimes) >= _MAX_SHARED_CLIENTS:
+            for candidate_key, candidate in list(_project_runtimes.items()):
+                if candidate.can_evict():
+                    evicted_runtime = _project_runtimes.pop(candidate_key)
+                    break
+            if evicted_runtime is not None:
+                break
+            _RUNTIME_AVAILABLE.wait()
+
+        runtime = ProjectRuntime(project_key)
+        _project_runtimes[project_key] = runtime
+        if reserve:
+            runtime._reserve_for_registry()
+
+    if evicted_runtime is not None:
+        evicted_runtime.close()
+
+    return runtime
+
+
+def get_project_runtime(project_path: Path | str) -> ProjectRuntime:
+    return _select_project_runtime(project_path)
+
+
+@contextmanager
+def _reserved_project_runtime(project_path: Path | str) -> Iterator[ProjectRuntime]:
+    runtime = _select_project_runtime(project_path, reserve=True)
+    try:
+        yield runtime
+    finally:
+        runtime._release_registry_reservation()
 
 
 def _active_transport(ctx: Context | None = None) -> str:
@@ -70,37 +293,39 @@ def _close_client(client: LeanLSPClient, message: str) -> None:
 
 
 def bind_lean_project_path(ctx: Context, project_path: Path | str) -> Path:
-    lifespan = ctx.request_context.lifespan_context
-    resolved_project = require_lean_project_path(project_path)
-    current_root: Path | None = getattr(lifespan, "lean_project_path", None)
-    if current_root is not None:
-        current_root = current_root.resolve(strict=False)
+    with _routing_lock(ctx):
+        lifespan = ctx.request_context.lifespan_context
+        resolved_project = require_lean_project_path(project_path)
+        current_root: Path | None = getattr(lifespan, "lean_project_path", None)
+        if current_root is not None:
+            current_root = current_root.resolve(strict=False)
 
-    if (
-        current_root is not None
-        and current_root != resolved_project
-        and not _project_switching_allowed(ctx)
-    ):
-        raise ValueError(
-            f"Project switching is disabled for `{_active_transport(ctx)}` transport. "
-            "Restart the server with LEAN_PROJECT_PATH set to the desired Lean project root."
-        )
-
-    if current_root != resolved_project:
-        lifespan.lean_project_path = resolved_project
-        current_client: LeanLSPClient | None = getattr(lifespan, "client", None)
         if (
-            current_client is not None
-            and getattr(current_client, "project_path", None) != resolved_project
+            current_root is not None
+            and current_root != resolved_project
+            and not _project_switching_allowed(ctx)
         ):
-            lifespan.client = None
+            raise ValueError(
+                f"Project switching is disabled for `{_active_transport(ctx)}` transport. "
+                "Restart the server with LEAN_PROJECT_PATH set to the desired Lean project root."
+            )
 
-    return resolved_project
+        if current_root != resolved_project:
+            lifespan.lean_project_path = resolved_project
+            current_client: LeanLSPClient | None = getattr(lifespan, "client", None)
+            if (
+                current_client is not None
+                and getattr(current_client, "project_path", None) != resolved_project
+            ):
+                lifespan.client = None
+
+        return resolved_project
 
 
 def get_path_policy(ctx: Context, project_path: Path | None = None) -> LeanPathPolicy:
-    lifespan = ctx.request_context.lifespan_context
-    root = project_path or getattr(lifespan, "lean_project_path", None)
+    with _routing_lock(ctx):
+        lifespan = ctx.request_context.lifespan_context
+        root = project_path or getattr(lifespan, "lean_project_path", None)
     if root is None:
         raise ValueError("lean project path is not set.")
     return build_lean_path_policy(root)
@@ -128,91 +353,76 @@ def _start_client(project_path: Path) -> LeanLSPClient:
     return client
 
 
-def _evict_oldest_client() -> None:
-    """Close and remove the oldest shared client to stay within the cap."""
-    oldest_key = next(iter(_shared_clients))
-    old = _shared_clients.pop(oldest_key)
-    _close_client(old, f"Evicted shared client for {oldest_key}")
-
-
-def _get_or_create_shared_client(lean_project_path: Path) -> LeanLSPClient:
-    project_key = lean_project_path.resolve(strict=False)
-
-    if project_key in _builds_in_progress:
-        raise ValueError(
-            "A project build is in progress. Retry after the build completes."
-        )
-
-    client = _shared_clients.get(project_key)
-    if client is not None and _client_is_alive(client):
-        return client
-
-    if client is not None:
-        _shared_clients.pop(project_key, None)
-        _close_client(client, "Shared Lean client close failed during restart")
-
-    if len(_shared_clients) >= _MAX_SHARED_CLIENTS:
-        _evict_oldest_client()
-
-    client = _start_client(project_key)
-    _shared_clients[project_key] = client
-    return client
-
-
 def set_build_in_progress(project_path: Path | str, value: bool) -> None:
-    project_key = Path(project_path).resolve(strict=False)
+    runtime = _select_project_runtime(project_path)
     if value:
-        _builds_in_progress.add(project_key)
+        runtime.detach_for_build()
     else:
-        _builds_in_progress.discard(project_key)
+        runtime.clear_build_in_progress()
 
 
 def replace_shared_client(
     project_path: Path | str, client: LeanLSPClient | None
 ) -> LeanLSPClient | None:
-    project_key = Path(project_path).resolve(strict=False)
-    previous = _shared_clients.pop(project_key, None)
-    if client is not None:
-        _shared_clients[project_key] = client
-    return previous
+    runtime = _select_project_runtime(project_path)
+    with runtime._condition:
+        previous = runtime._client
+        runtime._client = client
+        if client is not None:
+            runtime._build_in_progress = False
+            runtime._condition.notify_all()
+        return previous
 
 
 def close_shared_client(project_path: Path | str | None = None) -> None:
-    clients: list[LeanLSPClient] = []
-
+    runtimes: list[ProjectRuntime] = []
     with CLIENT_LOCK:
         if project_path is None:
-            clients = list(_shared_clients.values())
-            _shared_clients.clear()
-            _builds_in_progress.clear()
+            runtimes = list(_project_runtimes.values())
+            _project_runtimes.clear()
         else:
-            project_key = Path(project_path).resolve(strict=False)
-            client = _shared_clients.pop(project_key, None)
-            if client is not None:
-                clients.append(client)
-            _builds_in_progress.discard(project_key)
+            project_key = _project_key(project_path)
+            runtime = _project_runtimes.pop(project_key, None)
+            if runtime is not None:
+                runtimes.append(runtime)
 
-    for client in clients:
-        _close_client(client, "Shared Lean client close failed during shutdown")
+    for runtime in runtimes:
+        runtime.close()
 
 
 def startup_client(ctx: Context):
     """Initialize the Lean LSP client if not already set up."""
-    with CLIENT_LOCK:
+    with _routing_lock(ctx):
         configured_root = ctx.request_context.lifespan_context.lean_project_path
         if configured_root is None:
             raise ValueError("lean project path is not set.")
         lean_project_path = bind_lean_project_path(ctx, configured_root)
-        client = _get_or_create_shared_client(lean_project_path)
-        ctx.request_context.lifespan_context.client = client
+    with _reserved_project_runtime(lean_project_path) as runtime:
+        with runtime.operation() as op:
+            _set_lifespan_client_if_current(ctx, op)
+
+
+@contextmanager
+def lsp_client_for_project(ctx: Context) -> Iterator[LspClientOperation]:
+    """Yield the current project's shared LSP client for one serialized operation."""
+    with _routing_lock(ctx):
+        configured_root = ctx.request_context.lifespan_context.lean_project_path
+        if configured_root is None:
+            raise ValueError("lean project path is not set.")
+        project_path = bind_lean_project_path(ctx, configured_root)
+    with _reserved_project_runtime(project_path) as runtime:
+        with runtime.operation() as op:
+            _set_lifespan_client_if_current(ctx, op)
+            yield op
 
 
 def resolve_file_path(
     ctx: Context, file_path: str, *, require_exists: bool = True
 ) -> Path:
     """Resolve a file path with support for project-root-relative inputs."""
-    lifespan = ctx.request_context.lifespan_context
-    project_root: Path | None = getattr(lifespan, "lean_project_path", None)
+    with _routing_lock(ctx):
+        lifespan = ctx.request_context.lifespan_context
+        project_root: Path | None = getattr(lifespan, "lean_project_path", None)
     return resolve_input_path(
         file_path, project_root=project_root, require_exists=require_exists
     )
@@ -242,6 +452,15 @@ def _cacheable_project_dirs(project_path: Path, cache_dirs: list[str]) -> list[s
 
 def infer_project_path(file_path: str, ctx: Context | None = None) -> Path | None:
     """Infer and cache the Lean project path for a file WITHOUT starting the client."""
+    if ctx is not None:
+        with _routing_lock(ctx):
+            return _infer_project_path_locked(file_path, ctx)
+    return _infer_project_path_locked(file_path, None)
+
+
+def _infer_project_path_locked(
+    file_path: str, ctx: Context | None = None
+) -> Path | None:
     if ctx:
         lifespan = ctx.request_context.lifespan_context
         if not hasattr(lifespan, "project_cache"):
@@ -327,5 +546,33 @@ def setup_client_for_file(ctx: Context, file_path: str) -> str | None:
     if not policy.contains(resolved_file):
         return None
 
-    startup_client(ctx)
+    with _reserved_project_runtime(project_path) as runtime:
+        with runtime.operation() as op:
+            _set_lifespan_client_if_current(ctx, op)
     return policy.client_relative_path(resolved_file)
+
+
+@contextmanager
+def lsp_client_for_file(ctx: Context, file_path: str) -> Iterator[LspFileOperation]:
+    """Yield a file's shared LSP client for one serialized operation."""
+    try:
+        resolved_file = str(resolve_file_path(ctx, file_path))
+    except (FileNotFoundError, OSError) as exc:
+        raise InvalidLeanFilePathError(file_path) from exc
+
+    project_path = infer_project_path(resolved_file, ctx=ctx)
+    if project_path is None:
+        raise InvalidLeanFilePathError(file_path)
+
+    try:
+        policy = build_lean_path_policy(project_path)
+    except ValueError as exc:
+        raise InvalidLeanFilePathError(file_path) from exc
+    if not policy.contains(resolved_file):
+        raise InvalidLeanFilePathError(file_path)
+
+    rel_path = policy.client_relative_path(resolved_file)
+    with _reserved_project_runtime(project_path) as runtime:
+        with runtime.file_operation(path_policy=policy, rel_path=rel_path) as op:
+            _set_lifespan_client_if_current(ctx, op)
+            yield op

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -22,15 +22,19 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.fastmcp.utilities.logging import configure_logging, get_logger
 
 from lean_lsp_mcp.client_utils import (
-    CLIENT_LOCK,
+    CLIENT_LOCK as CLIENT_LOCK,
+    InvalidLeanFilePathError,
+    _reserved_project_runtime,
     _active_transport,
     _max_opened_files,
     _project_switching_allowed,
-    get_path_policy,
+    get_path_policy as get_path_policy,
     infer_project_path,
-    replace_shared_client,
     resolve_file_path,
-    set_build_in_progress,
+    lsp_client_for_file as lsp_client_for_file,
+    lsp_client_for_project as lsp_client_for_project,
+    replace_shared_client as replace_shared_client,
+    set_build_in_progress as set_build_in_progress,
     setup_client_for_file,
 )
 from lean_lsp_mcp.file_utils import (
@@ -503,6 +507,17 @@ async def _close_repl_for_project_switch(app_ctx: AppContext) -> None:
         logger.exception("REPL close failed during project switch")
 
 
+def _set_lifespan_client_for_project(
+    ctx: Context, project_path: Path, client: LeanLSPClient | None
+) -> None:
+    lifespan = ctx.request_context.lifespan_context
+    current_root: Path | None = getattr(lifespan, "lean_project_path", None)
+    if current_root is not None:
+        current_root = current_root.resolve(strict=False)
+    if current_root == project_path.resolve(strict=False):
+        lifespan.client = client
+
+
 async def _run_build(
     ctx: Context,
     lean_project_path_obj: Path,
@@ -553,25 +568,12 @@ async def _run_build(
         if remainder:
             await _handle_build_output_line(remainder)
 
+    runtime = None
     try:
-        clients_to_close: list[LeanLSPClient] = []
-        with CLIENT_LOCK:
-            set_build_in_progress(lean_project_path_obj, True)
+        with _reserved_project_runtime(lean_project_path_obj) as runtime:
+            runtime.detach_for_build()
             build_flag_set = True
-            client = ctx.request_context.lifespan_context.client
-            ctx.request_context.lifespan_context.client = None
-            shared_client = replace_shared_client(lean_project_path_obj, None)
-
-        for candidate in (client, shared_client):
-            if candidate is None or candidate in clients_to_close:
-                continue
-            clients_to_close.append(candidate)
-
-        for client_to_close in clients_to_close:
-            try:
-                client_to_close.close()
-            except Exception:
-                logger.exception("Lean client close failed during lsp_build restart")
+        _set_lifespan_client_for_project(ctx, lean_project_path_obj, None)
 
         if clean:
             await _safe_report_progress(
@@ -633,9 +635,10 @@ async def _run_build(
             )
 
         logger.info("Built project and re-started LSP client")
-        with CLIENT_LOCK:
-            replace_shared_client(lean_project_path_obj, client)
-        ctx.request_context.lifespan_context.client = client
+        if runtime is None:
+            raise RuntimeError("Lean project runtime was not reserved.")
+        runtime.install_restarted_client(client)
+        _set_lifespan_client_for_project(ctx, lean_project_path_obj, client)
 
         return BuildResult(
             success=True,
@@ -660,8 +663,8 @@ async def _run_build(
         )
     finally:
         if build_flag_set:
-            with CLIENT_LOCK:
-                set_build_in_progress(lean_project_path_obj, False)
+            if runtime is not None:
+                runtime.clear_build_in_progress()
 
 
 def _to_diagnostic_messages(diagnostics: Iterable[Dict]) -> List[DiagnosticMessage]:
@@ -1041,142 +1044,153 @@ def _multi_attempt_lsp(
     """Try tactics using LSP file modifications (fallback)."""
     if snippets is None:
         snippets = []
-    rel_path = setup_client_for_file(ctx, file_path)
-    if not rel_path:
-        _raise_invalid_path(file_path)
-
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
     try:
-        original_content = client.get_file_content(rel_path)
-    except Exception:
-        try:
-            policy = get_path_policy(ctx)
-            resolved_path = policy.validate_path(resolve_file_path(ctx, file_path))
-        except (FileNotFoundError, ValueError) as exc:
-            raise LeanToolError(str(exc)) from exc
-        original_content = get_file_contents(resolved_path)
-
-    lines = original_content.splitlines() if original_content is not None else []
-    line_context = _get_line_context(lines, line)
-    target_column = _resolve_multi_attempt_column(line_context, column)
-
-    # Snapshot baseline diagnostics before any edit. The line-range filter
-    # alone misses errors that surface at distant lines (e.g. a `whnf`
-    # heartbeat timeout reported at the leaf-statement line when a snippet's
-    # tactic forces aggressive unfolding) — that would produce a misleading
-    # `goals=[], diagnostics=[]` result indistinguishable from genuine
-    # tactic success. Diff against baseline to surface any *new* diagnostic
-    # the snippet introduced, regardless of its line position. Use
-    # leanclient's default cutoffs so the baseline wait is symmetric with
-    # the per-snippet `get_diagnostics` call below: asymmetric timeouts
-    # would leave the baseline partial while the per-snippet snapshot is
-    # complete, causing pre-existing diagnostics to be reported as
-    # snippet-introduced.
-    try:
-        baseline_diag = client.get_diagnostics(rel_path)
-        check_lsp_response(baseline_diag, "get_diagnostics")
-        if getattr(baseline_diag, "timed_out", False):
-            # Baseline is partial — set-diff would over-report. Disable
-            # it and fall back to local line-range filter only.
-            logger.warning(
-                "_multi_attempt_lsp: baseline diagnostics timed out — "
-                "set-diff disabled for this call (results limited to local "
-                "line-range filter)."
-            )
-            baseline_keys = None
-        else:
-            baseline_keys = {_diagnostic_identity(d) for d in baseline_diag}
-    except Exception:
-        logger.warning(
-            "_multi_attempt_lsp: baseline diagnostics unavailable — "
-            "set-diff disabled; results limited to local line-range filter.",
-            exc_info=True,
-        )
-        baseline_keys = None
-
-    try:
-        results: List[AttemptResult] = []
-        for i, snippet in enumerate(snippets):
-            # Restore original content before each iteration after the first.
-            # ``_prepare_multi_attempt_edit`` computes edit positions from the
-            # ORIGINAL ``line_context`` / ``len(lines)``; if the previous
-            # snippet's edit grew or shrank the file (EOF clamping), those
-            # positions no longer point to the original sorry region — the
-            # next snippet would patch the wrong content and report drifted
-            # diagnostics as snippet-introduced via ``extra_diag``.
-            if i > 0 and original_content is not None:
-                client.update_file_content(rel_path, original_content)
-            (
-                snippet_str,
-                change,
-                goal_line,
-                goal_column,
-                line_delta,
-            ) = _prepare_multi_attempt_edit(
-                line_context, target_column, snippet, len(lines), line
-            )
-            client.update_file(rel_path, [change])
-            diag = client.get_diagnostics(rel_path)
-            check_lsp_response(diag, "get_diagnostics")
-            filtered_diag = _filter_diagnostics_by_line_range(diag, line - 1, goal_line)
-            in_filtered = {id(d) for d in filtered_diag}
-            # Surface any new diagnostic — relative to the pre-edit baseline —
-            # even if outside the local line range. When baseline capture
-            # failed (baseline_keys is None), set-diff is disabled and we
-            # rely on the local filter only — same behavior as the original
-            # (pre-fix) code path.
-            if baseline_keys is None:
-                extra_diag = []
-            else:
-                # Multi-line snippets near end-of-file can grow the file
-                # (replacement range gets clamped). Pre-existing diagnostics
-                # at or past end_line get re-emitted at shifted line numbers
-                # post-edit, so their identity (which keys on line) won't
-                # match baseline_keys without compensating for the shift.
-                if line_delta:
-                    shifted_keys = _shift_baseline_keys(
-                        baseline_keys, edit_start_line=line - 1, line_delta=line_delta
+        with lsp_client_for_file(ctx, file_path) as lsp:
+            client = lsp.client
+            rel_path = lsp.rel_path
+            try:
+                original_content = client.get_file_content(rel_path)
+            except Exception:
+                try:
+                    resolved_path = lsp.path_policy.validate_path(
+                        resolve_file_path(ctx, file_path)
                     )
-                else:
-                    shifted_keys = baseline_keys
-                extra_diag = [
-                    d
-                    for d in diag
-                    if id(d) not in in_filtered
-                    and _diagnostic_identity(d) not in shifted_keys
-                ]
-            goal_result = client.get_goal(rel_path, goal_line, goal_column)
-            check_lsp_response(goal_result, "get_goal", allow_none=True)
-            goals = extract_goals_list(goal_result)
-            results.append(
-                AttemptResult(
-                    snippet=snippet_str,
-                    goals=goals,
-                    diagnostics=_to_diagnostic_messages(filtered_diag + extra_diag),
-                    timed_out=getattr(diag, "timed_out", False),
-                )
-            )
+                except (FileNotFoundError, ValueError) as exc:
+                    raise LeanToolError(str(exc)) from exc
+                original_content = get_file_contents(resolved_path)
 
-        return MultiAttemptResult(items=results)
-    finally:
-        if original_content is not None:
+            lines = (
+                original_content.splitlines() if original_content is not None else []
+            )
+            line_context = _get_line_context(lines, line)
+            target_column = _resolve_multi_attempt_column(line_context, column)
+
+            # Snapshot baseline diagnostics before any edit. The line-range filter
+            # alone misses errors that surface at distant lines (e.g. a `whnf`
+            # heartbeat timeout reported at the leaf-statement line when a snippet's
+            # tactic forces aggressive unfolding) — that would produce a misleading
+            # `goals=[], diagnostics=[]` result indistinguishable from genuine
+            # tactic success. Diff against baseline to surface any *new* diagnostic
+            # the snippet introduced, regardless of its line position. Use
+            # leanclient's default cutoffs so the baseline wait is symmetric with
+            # the per-snippet `get_diagnostics` call below: asymmetric timeouts
+            # would leave the baseline partial while the per-snippet snapshot is
+            # complete, causing pre-existing diagnostics to be reported as
+            # snippet-introduced.
             try:
-                client.update_file_content(rel_path, original_content)
-            except Exception as exc:
+                baseline_diag = client.get_diagnostics(rel_path)
+                check_lsp_response(baseline_diag, "get_diagnostics")
+                if getattr(baseline_diag, "timed_out", False):
+                    # Baseline is partial — set-diff would over-report. Disable
+                    # it and fall back to local line-range filter only.
+                    logger.warning(
+                        "_multi_attempt_lsp: baseline diagnostics timed out — "
+                        "set-diff disabled for this call (results limited to local "
+                        "line-range filter)."
+                    )
+                    baseline_keys = None
+                else:
+                    baseline_keys = {_diagnostic_identity(d) for d in baseline_diag}
+            except Exception:
                 logger.warning(
-                    "Failed to restore `%s` after multi_attempt: %s", rel_path, exc
+                    "_multi_attempt_lsp: baseline diagnostics unavailable — "
+                    "set-diff disabled; results limited to local line-range filter.",
+                    exc_info=True,
                 )
+                baseline_keys = None
+
             try:
-                # Force a disk resync so transient snippet edits do not leak
-                # into subsequent tool calls for already-open documents.
-                client.open_file(rel_path, force_reopen=True)
-            except Exception as exc:
-                logger.warning(
-                    "Failed to force-reopen `%s` after multi_attempt: %s",
-                    rel_path,
-                    exc,
-                )
+                results: List[AttemptResult] = []
+                for i, snippet in enumerate(snippets):
+                    # Restore original content before each iteration after the first.
+                    # ``_prepare_multi_attempt_edit`` computes edit positions from the
+                    # ORIGINAL ``line_context`` / ``len(lines)``; if the previous
+                    # snippet's edit grew or shrank the file (EOF clamping), those
+                    # positions no longer point to the original sorry region — the
+                    # next snippet would patch the wrong content and report drifted
+                    # diagnostics as snippet-introduced via ``extra_diag``.
+                    if i > 0 and original_content is not None:
+                        client.update_file_content(rel_path, original_content)
+                    (
+                        snippet_str,
+                        change,
+                        goal_line,
+                        goal_column,
+                        line_delta,
+                    ) = _prepare_multi_attempt_edit(
+                        line_context, target_column, snippet, len(lines), line
+                    )
+                    client.update_file(rel_path, [change])
+                    diag = client.get_diagnostics(rel_path)
+                    check_lsp_response(diag, "get_diagnostics")
+                    filtered_diag = _filter_diagnostics_by_line_range(
+                        diag, line - 1, goal_line
+                    )
+                    in_filtered = {id(d) for d in filtered_diag}
+                    # Surface any new diagnostic — relative to the pre-edit baseline —
+                    # even if outside the local line range. When baseline capture
+                    # failed (baseline_keys is None), set-diff is disabled and we
+                    # rely on the local filter only — same behavior as the original
+                    # (pre-fix) code path.
+                    if baseline_keys is None:
+                        extra_diag = []
+                    else:
+                        # Multi-line snippets near end-of-file can grow the file
+                        # (replacement range gets clamped). Pre-existing diagnostics
+                        # at or past end_line get re-emitted at shifted line numbers
+                        # post-edit, so their identity (which keys on line) won't
+                        # match baseline_keys without compensating for the shift.
+                        if line_delta:
+                            shifted_keys = _shift_baseline_keys(
+                                baseline_keys,
+                                edit_start_line=line - 1,
+                                line_delta=line_delta,
+                            )
+                        else:
+                            shifted_keys = baseline_keys
+                        extra_diag = [
+                            d
+                            for d in diag
+                            if id(d) not in in_filtered
+                            and _diagnostic_identity(d) not in shifted_keys
+                        ]
+                    goal_result = client.get_goal(rel_path, goal_line, goal_column)
+                    check_lsp_response(goal_result, "get_goal", allow_none=True)
+                    goals = extract_goals_list(goal_result)
+                    results.append(
+                        AttemptResult(
+                            snippet=snippet_str,
+                            goals=goals,
+                            diagnostics=_to_diagnostic_messages(
+                                filtered_diag + extra_diag
+                            ),
+                            timed_out=getattr(diag, "timed_out", False),
+                        )
+                    )
+
+                return MultiAttemptResult(items=results)
+            finally:
+                if original_content is not None:
+                    try:
+                        client.update_file_content(rel_path, original_content)
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to restore `%s` after multi_attempt: %s",
+                            rel_path,
+                            exc,
+                        )
+                    try:
+                        # Force a disk resync so transient snippet edits do not leak
+                        # into subsequent tool calls for already-open documents.
+                        client.open_file(rel_path, force_reopen=True)
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to force-reopen `%s` after multi_attempt: %s",
+                            rel_path,
+                            exc,
+                        )
+    except InvalidLeanFilePathError:
+        _raise_invalid_path(file_path)
 
 
 # Register the tool subpackage last: each submodule's @mcp.tool decorators run

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -22,19 +22,16 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.fastmcp.utilities.logging import configure_logging, get_logger
 
 from lean_lsp_mcp.client_utils import (
-    CLIENT_LOCK as CLIENT_LOCK,
     InvalidLeanFilePathError,
     _reserved_project_runtime,
     _active_transport,
     _max_opened_files,
     _project_switching_allowed,
-    get_path_policy as get_path_policy,
     infer_project_path,
     resolve_file_path,
-    lsp_client_for_file as lsp_client_for_file,
-    lsp_client_for_project as lsp_client_for_project,
-    replace_shared_client as replace_shared_client,
-    set_build_in_progress as set_build_in_progress,
+    lsp_client_for_file,
+    lsp_client_for_project,
+    set_lifespan_client_for_project,
     setup_client_for_file,
 )
 from lean_lsp_mcp.file_utils import (
@@ -419,6 +416,9 @@ mcp = FastMCP(**mcp_kwargs)
 # or by tests through monkeypatching. Listing them in __all__ marks them as
 # intentionally exported so they are not pruned as "unused imports".
 __all__ = [
+    "InvalidLeanFilePathError",
+    "lsp_client_for_file",
+    "lsp_client_for_project",
     "setup_client_for_file",
     "resolve_file_path",
     "get_file_contents",
@@ -507,17 +507,6 @@ async def _close_repl_for_project_switch(app_ctx: AppContext) -> None:
         logger.exception("REPL close failed during project switch")
 
 
-def _set_lifespan_client_for_project(
-    ctx: Context, project_path: Path, client: LeanLSPClient | None
-) -> None:
-    lifespan = ctx.request_context.lifespan_context
-    current_root: Path | None = getattr(lifespan, "lean_project_path", None)
-    if current_root is not None:
-        current_root = current_root.resolve(strict=False)
-    if current_root == project_path.resolve(strict=False):
-        lifespan.client = client
-
-
 async def _run_build(
     ctx: Context,
     lean_project_path_obj: Path,
@@ -568,12 +557,16 @@ async def _run_build(
         if remainder:
             await _handle_build_output_line(remainder)
 
+    def _detach_runtime_for_build():
+        with _reserved_project_runtime(lean_project_path_obj) as reserved_runtime:
+            reserved_runtime.detach_for_build()
+            return reserved_runtime
+
     runtime = None
     try:
-        with _reserved_project_runtime(lean_project_path_obj) as runtime:
-            runtime.detach_for_build()
-            build_flag_set = True
-        _set_lifespan_client_for_project(ctx, lean_project_path_obj, None)
+        runtime = await asyncio.to_thread(_detach_runtime_for_build)
+        build_flag_set = True
+        set_lifespan_client_for_project(ctx, lean_project_path_obj, None)
 
         if clean:
             await _safe_report_progress(
@@ -638,7 +631,7 @@ async def _run_build(
         if runtime is None:
             raise RuntimeError("Lean project runtime was not reserved.")
         runtime.install_restarted_client(client)
-        _set_lifespan_client_for_project(ctx, lean_project_path_obj, client)
+        set_lifespan_client_for_project(ctx, lean_project_path_obj, client)
 
         return BuildResult(
             success=True,

--- a/src/lean_lsp_mcp/tools/analysis.py
+++ b/src/lean_lsp_mcp/tools/analysis.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import os
 import uuid
 from collections.abc import Iterable
+from pathlib import Path
 from typing import Annotated, Dict, List, Optional
 
-from leanclient import DocumentContentChange, LeanLSPClient
+from leanclient import DocumentContentChange
 from mcp.server.fastmcp import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -16,7 +17,6 @@ from lean_lsp_mcp import server
 from lean_lsp_mcp.client_utils import (
     get_path_policy,
     infer_project_path,
-    startup_client,
 )
 from lean_lsp_mcp.models import (
     HypothesisStatus,
@@ -79,50 +79,46 @@ def run_code(
     code: Annotated[str, Field(description="Self-contained Lean code with imports")],
 ) -> RunResult:
     """Run a code snippet and return diagnostics. Must include all imports."""
-    lifespan_context = ctx.request_context.lifespan_context
-    lean_project_path = lifespan_context.lean_project_path
-    if lean_project_path is None:
-        raise server.LeanToolError(
-            "No valid Lean project path found. Run another tool first to set it up."
-        )
-
-    # Use a unique snippet filename to avoid collisions under concurrency
     rel_path = f"_mcp_snippet_{uuid.uuid4().hex}.lean"
-    abs_path = lean_project_path / rel_path
-
-    try:
-        with open(abs_path, "w", encoding="utf-8") as f:
-            f.write(code)
-    except Exception as e:
-        raise server.LeanToolError(f"Error writing code snippet: {e}")
-
-    client: LeanLSPClient | None = lifespan_context.client
+    abs_path: Path | None = None
     raw_diagnostics: Iterable[Dict] = []
     opened_file = False
 
     try:
-        if client is None:
-            startup_client(ctx)
-            client = lifespan_context.client
-            if client is None:
-                raise server.LeanToolError(
-                    "Failed to initialize Lean client for run_code."
-                )
-
-        client.open_file(rel_path)
-        opened_file = True
-        raw_diagnostics = client.get_diagnostics(rel_path, inactivity_timeout=15.0)
-        check_lsp_response(raw_diagnostics, "get_diagnostics")
-    finally:
-        if opened_file:
+        with server.lsp_client_for_project(ctx) as lsp:
+            client = lsp.client
+            abs_path = lsp.project_path / rel_path
             try:
-                client.close_files([rel_path])
-            except Exception as exc:
-                server.logger.warning(
-                    "Failed to close `%s` after run_code: %s", rel_path, exc
+                with open(abs_path, "w", encoding="utf-8") as f:
+                    f.write(code)
+            except Exception as e:
+                raise server.LeanToolError(f"Error writing code snippet: {e}")
+
+            try:
+                client.open_file(rel_path)
+                opened_file = True
+                raw_diagnostics = client.get_diagnostics(
+                    rel_path, inactivity_timeout=15.0
                 )
+                check_lsp_response(raw_diagnostics, "get_diagnostics")
+            finally:
+                if opened_file:
+                    try:
+                        client.close_files([rel_path])
+                    except Exception as exc:
+                        server.logger.warning(
+                            "Failed to close `%s` after run_code: %s", rel_path, exc
+                        )
+    except ValueError as exc:
+        if "lean project path is not set" in str(exc):
+            raise server.LeanToolError(
+                "No valid Lean project path found. Run another tool first to set it up."
+            ) from exc
+        raise
+    finally:
         try:
-            os.remove(abs_path)
+            if abs_path is not None:
+                os.remove(abs_path)
         except FileNotFoundError:
             pass
         except Exception as e:
@@ -167,58 +163,59 @@ def verify_theorem(
     )
 
     theorem_name = server._validate_theorem_name(theorem_name)
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            client = lsp.client
+            rel_path = lsp.rel_path
+            try:
+                abs_path = lsp.path_policy.validate_path(
+                    server.resolve_file_path(ctx, file_path)
+                )
+            except (FileNotFoundError, ValueError) as exc:
+                raise server.LeanToolError(str(exc)) from exc
+
+            try:
+                original_content = client.get_file_content(rel_path)
+            except Exception:
+                original_content = server.get_file_contents(abs_path)
+
+            snippet = f"\n#print axioms _root_.{theorem_name}\n"
+            original_lines = original_content.split("\n")
+            appended_line = len(original_lines)  # 0-indexed line where snippet starts
+
+            try:
+                change = DocumentContentChange(
+                    snippet,
+                    (appended_line, 0),
+                    (appended_line, 0),
+                )
+                client.update_file(rel_path, [change])
+                raw = client.get_diagnostics(
+                    rel_path, start_line=appended_line, inactivity_timeout=120.0
+                )
+                check_lsp_response(raw, "get_diagnostics")
+
+                appended_diags = list(raw)
+
+                if err := check_axiom_errors(appended_diags):
+                    raise server.LeanToolError(f"Axiom check failed: {err}")
+
+                axioms = parse_axioms(appended_diags)
+            finally:
+                try:
+                    client.update_file_content(rel_path, original_content)
+                except Exception as exc:
+                    server.logger.warning(
+                        "Failed to restore `%s` after verify: %s", rel_path, exc
+                    )
+                try:
+                    client.open_file(rel_path, force_reopen=True)
+                except Exception as exc:
+                    server.logger.warning(
+                        "Failed to force-reopen `%s` after verify: %s", rel_path, exc
+                    )
+    except server.InvalidLeanFilePathError:
         server._raise_invalid_path(file_path)
-
-    try:
-        policy = get_path_policy(ctx)
-        abs_path = policy.validate_path(server.resolve_file_path(ctx, file_path))
-    except (FileNotFoundError, ValueError) as exc:
-        raise server.LeanToolError(str(exc)) from exc
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
-
-    try:
-        original_content = client.get_file_content(rel_path)
-    except Exception:
-        original_content = server.get_file_contents(abs_path)
-
-    snippet = f"\n#print axioms _root_.{theorem_name}\n"
-    original_lines = original_content.split("\n")
-    appended_line = len(original_lines)  # 0-indexed line where snippet starts
-
-    try:
-        change = DocumentContentChange(
-            snippet,
-            (appended_line, 0),
-            (appended_line, 0),
-        )
-        client.update_file(rel_path, [change])
-        raw = client.get_diagnostics(
-            rel_path, start_line=appended_line, inactivity_timeout=120.0
-        )
-        check_lsp_response(raw, "get_diagnostics")
-
-        appended_diags = list(raw)
-
-        if err := check_axiom_errors(appended_diags):
-            raise server.LeanToolError(f"Axiom check failed: {err}")
-
-        axioms = parse_axioms(appended_diags)
-    finally:
-        try:
-            client.update_file_content(rel_path, original_content)
-        except Exception as exc:
-            server.logger.warning(
-                "Failed to restore `%s` after verify: %s", rel_path, exc
-            )
-        try:
-            client.open_file(rel_path, force_reopen=True)
-        except Exception as exc:
-            server.logger.warning(
-                "Failed to force-reopen `%s` after verify: %s", rel_path, exc
-            )
 
     w: list[SourceWarning] = []
     if scan_source:
@@ -285,150 +282,156 @@ def minimal_hypotheses(
     )
 
     theorem_name = server._validate_theorem_name(theorem_name)
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
-        server._raise_invalid_path(file_path)
-
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
     try:
-        original_content = client.get_file_content(rel_path)
-    except Exception:
-        try:
-            policy = get_path_policy(ctx)
-            abs_path = policy.validate_path(server.resolve_file_path(ctx, file_path))
-        except (FileNotFoundError, ValueError) as exc:
-            raise server.LeanToolError(str(exc)) from exc
-        original_content = server.get_file_contents(abs_path)
-
-    if original_content is None:
-        raise server.LeanToolError(f"Could not read content for {rel_path}")
-
-    bare_name = theorem_name.split(".")[-1]
-    if not theorem_declared(original_content, bare_name):
-        raise server.LeanToolError(
-            f"Could not find theorem '{theorem_name}' in {rel_path}."
-        )
-
-    binders = find_theorem_binders(original_content, bare_name)
-    explicit = explicit_hypotheses(binders)
-    skipped = len(binders) - len(explicit)
-
-    # Theorem found but nothing explicit to probe (no binders, or only
-    # implicit/instance binders): there is no hypothesis to minimize.
-    if not explicit:
-        return MinimalHypothesesResult(
-            theorem_name=theorem_name,
-            file=rel_path,
-            verdicts=[],
-            skipped_implicit=skipped,
-        )
-
-    def _error_key(diag: Dict) -> tuple[int, int, str]:
-        """Stable identifier for a single LSP diagnostic — used to filter the
-        set of *new* errors against the pre-modification baseline. Line and
-        column may shift slightly if a multi-line binder is removed, but most
-        binders are single-line so (line, column, message[:120]) is stable
-        in practice.
-        """
-        r = diag.get("fullRange", diag.get("range")) or {}
-        start = r.get("start", {})
-        return (
-            int(start.get("line", -1)),
-            int(start.get("character", -1)),
-            str(diag.get("message", ""))[:120],
-        )
-
-    baseline = client.get_diagnostics(rel_path, inactivity_timeout=inactivity_timeout)
-    check_lsp_response(baseline, "get_diagnostics")
-    baseline_keys = {
-        _error_key(d) for d in list(baseline or []) if d.get("severity") == 1
-    }
-
-    verdicts: list[HypothesisVerdict] = []
-    try:
-        for binder, start, end in explicit:
-            modified = drop_binder(original_content, start, end)
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            client = lsp.client
+            rel_path = lsp.rel_path
             try:
-                client.update_file_content(rel_path, modified)
-            except Exception as exc:
-                verdicts.append(
-                    HypothesisVerdict(
-                        binder=binder.strip(),
-                        status=HypothesisStatus.error,
-                        detail=f"update_file_content failed: {exc}",
+                original_content = client.get_file_content(rel_path)
+            except Exception:
+                try:
+                    policy = get_path_policy(ctx)
+                    abs_path = policy.validate_path(
+                        server.resolve_file_path(ctx, file_path)
                     )
-                )
-                continue
+                except (FileNotFoundError, ValueError) as exc:
+                    raise server.LeanToolError(str(exc)) from exc
+                original_content = server.get_file_contents(abs_path)
 
-            diag = client.get_diagnostics(
+            if original_content is None:
+                raise server.LeanToolError(f"Could not read content for {rel_path}")
+
+            bare_name = theorem_name.split(".")[-1]
+            if not theorem_declared(original_content, bare_name):
+                raise server.LeanToolError(
+                    f"Could not find theorem '{theorem_name}' in {rel_path}."
+                )
+
+            binders = find_theorem_binders(original_content, bare_name)
+            explicit = explicit_hypotheses(binders)
+            skipped = len(binders) - len(explicit)
+
+            # Theorem found but nothing explicit to probe (no binders, or only
+            # implicit/instance binders): there is no hypothesis to minimize.
+            if not explicit:
+                return MinimalHypothesesResult(
+                    theorem_name=theorem_name,
+                    file=rel_path,
+                    verdicts=[],
+                    skipped_implicit=skipped,
+                )
+
+            def _error_key(diag: Dict) -> tuple[int, int, str]:
+                """Stable identifier for a single LSP diagnostic — used to filter the
+                set of *new* errors against the pre-modification baseline. Line and
+                column may shift slightly if a multi-line binder is removed, but most
+                binders are single-line so (line, column, message[:120]) is stable
+                in practice.
+                """
+                r = diag.get("fullRange", diag.get("range")) or {}
+                start = r.get("start", {})
+                return (
+                    int(start.get("line", -1)),
+                    int(start.get("character", -1)),
+                    str(diag.get("message", ""))[:120],
+                )
+
+            baseline = client.get_diagnostics(
                 rel_path, inactivity_timeout=inactivity_timeout
             )
+            check_lsp_response(baseline, "get_diagnostics")
+            baseline_keys = {
+                _error_key(d) for d in list(baseline or []) if d.get("severity") == 1
+            }
+
+            verdicts: list[HypothesisVerdict] = []
             try:
-                check_lsp_response(diag, "get_diagnostics")
-            except Exception as exc:
-                verdicts.append(
-                    HypothesisVerdict(
-                        binder=binder.strip(),
-                        status=HypothesisStatus.error,
-                        detail=str(exc)[:200],
-                    )
-                )
-                continue
+                for binder, start, end in explicit:
+                    modified = drop_binder(original_content, start, end)
+                    try:
+                        client.update_file_content(rel_path, modified)
+                    except Exception as exc:
+                        verdicts.append(
+                            HypothesisVerdict(
+                                binder=binder.strip(),
+                                status=HypothesisStatus.error,
+                                detail=f"update_file_content failed: {exc}",
+                            )
+                        )
+                        continue
 
-            if getattr(diag, "timed_out", False):
-                verdicts.append(
-                    HypothesisVerdict(
-                        binder=binder.strip(),
-                        status=HypothesisStatus.error,
-                        detail=f"LSP elaboration timed out after {inactivity_timeout}s",
+                    diag = client.get_diagnostics(
+                        rel_path, inactivity_timeout=inactivity_timeout
                     )
-                )
-                continue
+                    try:
+                        check_lsp_response(diag, "get_diagnostics")
+                    except Exception as exc:
+                        verdicts.append(
+                            HypothesisVerdict(
+                                binder=binder.strip(),
+                                status=HypothesisStatus.error,
+                                detail=str(exc)[:200],
+                            )
+                        )
+                        continue
 
-            new_errors = [
-                d
-                for d in list(diag or [])
-                if d.get("severity") == 1 and _error_key(d) not in baseline_keys
-            ]
-            if new_errors:
-                breaks = server._to_diagnostic_messages(new_errors)
-                verdicts.append(
-                    HypothesisVerdict(
-                        binder=binder.strip(),
-                        status=HypothesisStatus.load_bearing,
-                        breaks=breaks,
+                    if getattr(diag, "timed_out", False):
+                        verdicts.append(
+                            HypothesisVerdict(
+                                binder=binder.strip(),
+                                status=HypothesisStatus.error,
+                                detail=f"LSP elaboration timed out after {inactivity_timeout}s",
+                            )
+                        )
+                        continue
+
+                    new_errors = [
+                        d
+                        for d in list(diag or [])
+                        if d.get("severity") == 1 and _error_key(d) not in baseline_keys
+                    ]
+                    if new_errors:
+                        breaks = server._to_diagnostic_messages(new_errors)
+                        verdicts.append(
+                            HypothesisVerdict(
+                                binder=binder.strip(),
+                                status=HypothesisStatus.load_bearing,
+                                breaks=breaks,
+                            )
+                        )
+                    else:
+                        verdicts.append(
+                            HypothesisVerdict(
+                                binder=binder.strip(),
+                                status=HypothesisStatus.removable,
+                            )
+                        )
+            finally:
+                try:
+                    client.update_file_content(rel_path, original_content)
+                except Exception as exc:
+                    server.logger.warning(
+                        "Failed to restore `%s` after minimal_hypotheses: %s",
+                        rel_path,
+                        exc,
                     )
-                )
-            else:
-                verdicts.append(
-                    HypothesisVerdict(
-                        binder=binder.strip(),
-                        status=HypothesisStatus.removable,
+                try:
+                    client.open_file(rel_path, force_reopen=True)
+                except Exception as exc:
+                    server.logger.warning(
+                        "Failed to force-reopen `%s` after minimal_hypotheses: %s",
+                        rel_path,
+                        exc,
                     )
-                )
-    finally:
-        try:
-            client.update_file_content(rel_path, original_content)
-        except Exception as exc:
-            server.logger.warning(
-                "Failed to restore `%s` after minimal_hypotheses: %s", rel_path, exc
+
+            return MinimalHypothesesResult(
+                theorem_name=theorem_name,
+                file=rel_path,
+                verdicts=verdicts,
+                skipped_implicit=skipped,
             )
-        try:
-            client.open_file(rel_path, force_reopen=True)
-        except Exception as exc:
-            server.logger.warning(
-                "Failed to force-reopen `%s` after minimal_hypotheses: %s",
-                rel_path,
-                exc,
-            )
-
-    return MinimalHypothesesResult(
-        theorem_name=theorem_name,
-        file=rel_path,
-        verdicts=verdicts,
-        skipped_implicit=skipped,
-    )
+    except server.InvalidLeanFilePathError:
+        server._raise_invalid_path(file_path)
 
 
 @server.mcp.tool(

--- a/src/lean_lsp_mcp/tools/analysis.py
+++ b/src/lean_lsp_mcp/tools/analysis.py
@@ -14,10 +14,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from lean_lsp_mcp import server
-from lean_lsp_mcp.client_utils import (
-    get_path_policy,
-    infer_project_path,
-)
+from lean_lsp_mcp.client_utils import get_path_policy, infer_project_path
 from lean_lsp_mcp.models import (
     HypothesisStatus,
     HypothesisVerdict,
@@ -290,8 +287,7 @@ def minimal_hypotheses(
                 original_content = client.get_file_content(rel_path)
             except Exception:
                 try:
-                    policy = get_path_policy(ctx)
-                    abs_path = policy.validate_path(
+                    abs_path = lsp.path_policy.validate_path(
                         server.resolve_file_path(ctx, file_path)
                     )
                 except (FileNotFoundError, ValueError) as exc:

--- a/src/lean_lsp_mcp/tools/diagnostics.py
+++ b/src/lean_lsp_mcp/tools/diagnostics.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Annotated, Literal, Optional
 
-from leanclient import LeanLSPClient
 from mcp.server.fastmcp import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -41,12 +40,12 @@ def file_outline(
     ] = None,
 ) -> FileOutline:
     """Get imports and declarations with type signatures. Token-efficient."""
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            rel_path = lsp.rel_path
+            return generate_outline_data(lsp.client, rel_path, max_declarations)
+    except server.InvalidLeanFilePathError:
         server._raise_invalid_path(file_path)
-
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    return generate_outline_data(client, rel_path, max_declarations)
 
 
 @server.mcp.tool(
@@ -92,45 +91,45 @@ def diagnostic_messages(
     ] = None,
 ) -> DiagnosticsResult | InteractiveDiagnosticsResult:
     """Get compiler diagnostics (errors, warnings, infos) for a Lean file."""
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
-        server._raise_invalid_path(file_path)
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            client = lsp.client
+            rel_path = lsp.rel_path
 
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
+            # If declaration_name is provided, get its range and use that for filtering
+            if declaration_name:
+                decl_range = get_declaration_range(client, rel_path, declaration_name)
+                if decl_range is None:
+                    raise server.LeanToolError(
+                        f"Declaration '{declaration_name}' not found in file."
+                    )
+                start_line, end_line = decl_range
 
-    # If declaration_name is provided, get its range and use that for filtering
-    if declaration_name:
-        decl_range = get_declaration_range(client, rel_path, declaration_name)
-        if decl_range is None:
-            raise server.LeanToolError(
-                f"Declaration '{declaration_name}' not found in file."
+            # Convert 1-indexed to 0-indexed for leanclient
+            start_line_0 = (start_line - 1) if start_line is not None else None
+            end_line_0 = (end_line - 1) if end_line is not None else None
+
+            if interactive:
+                diagnostics = client.get_interactive_diagnostics(
+                    rel_path, start_line=start_line_0, end_line=end_line_0
+                )
+                return InteractiveDiagnosticsResult(diagnostics=diagnostics)
+
+            result = client.get_diagnostics(
+                rel_path,
+                start_line=start_line_0,
+                end_line=end_line_0,
+                inactivity_timeout=15.0,
             )
-        start_line, end_line = decl_range
 
-    # Convert 1-indexed to 0-indexed for leanclient
-    start_line_0 = (start_line - 1) if start_line is not None else None
-    end_line_0 = (end_line - 1) if end_line is not None else None
-
-    if interactive:
-        diagnostics = client.get_interactive_diagnostics(
-            rel_path, start_line=start_line_0, end_line=end_line_0
-        )
-        return InteractiveDiagnosticsResult(diagnostics=diagnostics)
-
-    result = client.get_diagnostics(
-        rel_path,
-        start_line=start_line_0,
-        end_line=end_line_0,
-        inactivity_timeout=15.0,
-    )
-
-    return server._process_diagnostics(
-        result.diagnostics,
-        result.success,
-        severity=severity,
-        timed_out=getattr(result, "timed_out", False),
-    )
+            return server._process_diagnostics(
+                result.diagnostics,
+                result.success,
+                severity=severity,
+                timed_out=getattr(result, "timed_out", False),
+            )
+    except server.InvalidLeanFilePathError:
+        server._raise_invalid_path(file_path)
 
 
 @server.mcp.tool(
@@ -148,97 +147,102 @@ def code_actions(
     line: Annotated[int, Field(description="Line number (1-indexed)", ge=1)],
 ) -> CodeActionsResult:
     """Get LSP code actions for a line. Returns resolved edits for TryThis suggestions (simp?, exact?, apply?) and other quick fixes."""
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
-        server._raise_invalid_path(file_path)
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            client = lsp.client
+            rel_path = lsp.rel_path
 
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
-
-    # Get diagnostics on line to discover code action ranges
-    diags = client.get_diagnostics(
-        rel_path, start_line=line - 1, end_line=line - 1, inactivity_timeout=15.0
-    )
-
-    # Query code actions for each diagnostic's range, dedup by title
-    seen: set[str] = set()
-    raw_actions: list[dict] = []
-    for diag in diags.diagnostics:
-        r = diag.get("fullRange", diag.get("range"))
-        if not r:
-            continue
-        s, e = r["start"], r["end"]
-        for action in client.get_code_actions(
-            rel_path, s["line"], s["character"], e["line"], e["character"]
-        ):
-            if action.get("title", "") not in seen:
-                seen.add(action.get("title", ""))
-                raw_actions.append(action)
-
-    # Fallback: if no diagnostics on the line, retry across the full line
-    # range. Tactic `TryThis` suggestions (`simp?`, `exact?`, `apply?`) and
-    # other `IdeView` quick-actions can be registered without an
-    # accompanying diagnostic, so the diagnostic-driven scan misses them.
-    if not raw_actions:
-        line_str = ""
-        try:
-            resolved_path = server.resolve_file_path(ctx, file_path)
-            line_text = resolved_path.read_text(encoding="utf-8").splitlines()
-            line_str = line_text[line - 1] if 0 < line <= len(line_text) else ""
-        except (
-            OSError,
-            IndexError,
-            UnicodeDecodeError,
-            ValueError,
-            RuntimeError,
-        ) as exc:
-            # Path-resolution failures are common for files in
-            # `.lake/packages/...` (dep paths that `setup_client_for_file`
-            # accepts but `resolve_file_path(require_exists=True)` rejects).
-            # `RuntimeError` covers CPython's symlink-loop raise from
-            # ``Path.resolve(strict=True)``.
-            # Log so production failures aren't silently invisible.
-            server.logger.debug(
-                "lean_code_actions fallback: could not read line text from %s: %s",
-                file_path,
-                exc,
+            # Get diagnostics on line to discover code action ranges
+            diags = client.get_diagnostics(
+                rel_path,
+                start_line=line - 1,
+                end_line=line - 1,
+                inactivity_timeout=15.0,
             )
-            line_str = ""
-        if line_str:
-            # LSP positions are UTF-16 code units, not Python codepoints —
-            # surrogate-pair characters (e.g. `𝕜`) count as 2 units. Use the
-            # UTF-16 length so the end-column reaches the actual end of the
-            # line on those rare inputs.
-            end_col = len(line_str.encode("utf-16-le")) // 2
-            for action in client.get_code_actions(
-                rel_path, line - 1, 0, line - 1, end_col
-            ):
-                if action.get("title", "") not in seen:
-                    seen.add(action.get("title", ""))
-                    raw_actions.append(action)
 
-    # Resolve and convert
-    actions: list[CodeAction] = []
-    for raw in raw_actions:
-        resolved = raw if "edit" in raw else client.get_code_action_resolve(raw)
-        if isinstance(resolved, dict) and "error" in resolved:
-            continue
-        actions.append(
-            CodeAction(
-                title=raw.get("title", ""),
-                is_preferred=raw.get("isPreferred", False),
-                edits=[
-                    CodeActionEdit(
-                        new_text=edit["newText"],
-                        start_line=edit["range"]["start"]["line"] + 1,
-                        start_column=edit["range"]["start"]["character"] + 1,
-                        end_line=edit["range"]["end"]["line"] + 1,
-                        end_column=edit["range"]["end"]["character"] + 1,
+            # Query code actions for each diagnostic's range, dedup by title
+            seen: set[str] = set()
+            raw_actions: list[dict] = []
+            for diag in diags.diagnostics:
+                r = diag.get("fullRange", diag.get("range"))
+                if not r:
+                    continue
+                s, e = r["start"], r["end"]
+                for action in client.get_code_actions(
+                    rel_path, s["line"], s["character"], e["line"], e["character"]
+                ):
+                    if action.get("title", "") not in seen:
+                        seen.add(action.get("title", ""))
+                        raw_actions.append(action)
+
+            # Fallback: if no diagnostics on the line, retry across the full line
+            # range. Tactic `TryThis` suggestions (`simp?`, `exact?`, `apply?`) and
+            # other `IdeView` quick-actions can be registered without an
+            # accompanying diagnostic, so the diagnostic-driven scan misses them.
+            if not raw_actions:
+                line_str = ""
+                try:
+                    resolved_path = server.resolve_file_path(ctx, file_path)
+                    line_text = resolved_path.read_text(encoding="utf-8").splitlines()
+                    line_str = line_text[line - 1] if 0 < line <= len(line_text) else ""
+                except (
+                    OSError,
+                    IndexError,
+                    UnicodeDecodeError,
+                    ValueError,
+                    RuntimeError,
+                ) as exc:
+                    # Path-resolution failures are common for files in
+                    # `.lake/packages/...` (dep paths that `setup_client_for_file`
+                    # accepts but `resolve_file_path(require_exists=True)` rejects).
+                    # `RuntimeError` covers CPython's symlink-loop raise from
+                    # ``Path.resolve(strict=True)``.
+                    # Log so production failures aren't silently invisible.
+                    server.logger.debug(
+                        "lean_code_actions fallback: could not read line text from %s: %s",
+                        file_path,
+                        exc,
                     )
-                    for dc in resolved.get("edit", {}).get("documentChanges", [])
-                    for edit in dc.get("edits", [])
-                ],
-            )
-        )
+                    line_str = ""
+                if line_str:
+                    # LSP positions are UTF-16 code units, not Python codepoints —
+                    # surrogate-pair characters (e.g. `𝕜`) count as 2 units. Use the
+                    # UTF-16 length so the end-column reaches the actual end of the
+                    # line on those rare inputs.
+                    end_col = len(line_str.encode("utf-16-le")) // 2
+                    for action in client.get_code_actions(
+                        rel_path, line - 1, 0, line - 1, end_col
+                    ):
+                        if action.get("title", "") not in seen:
+                            seen.add(action.get("title", ""))
+                            raw_actions.append(action)
 
-    return CodeActionsResult(actions=actions)
+            # Resolve and convert
+            actions: list[CodeAction] = []
+            for raw in raw_actions:
+                resolved = raw if "edit" in raw else client.get_code_action_resolve(raw)
+                if isinstance(resolved, dict) and "error" in resolved:
+                    continue
+                actions.append(
+                    CodeAction(
+                        title=raw.get("title", ""),
+                        is_preferred=raw.get("isPreferred", False),
+                        edits=[
+                            CodeActionEdit(
+                                new_text=edit["newText"],
+                                start_line=edit["range"]["start"]["line"] + 1,
+                                start_column=edit["range"]["start"]["character"] + 1,
+                                end_line=edit["range"]["end"]["line"] + 1,
+                                end_column=edit["range"]["end"]["character"] + 1,
+                            )
+                            for dc in resolved.get("edit", {}).get(
+                                "documentChanges", []
+                            )
+                            for edit in dc.get("edits", [])
+                        ],
+                    )
+                )
+
+            return CodeActionsResult(actions=actions)
+    except server.InvalidLeanFilePathError:
+        server._raise_invalid_path(file_path)

--- a/src/lean_lsp_mcp/tools/diagnostics.py
+++ b/src/lean_lsp_mcp/tools/diagnostics.py
@@ -192,12 +192,6 @@ def code_actions(
                     ValueError,
                     RuntimeError,
                 ) as exc:
-                    # Path-resolution failures are common for files in
-                    # `.lake/packages/...` (dep paths that `setup_client_for_file`
-                    # accepts but `resolve_file_path(require_exists=True)` rejects).
-                    # `RuntimeError` covers CPython's symlink-loop raise from
-                    # ``Path.resolve(strict=True)``.
-                    # Log so production failures aren't silently invisible.
                     server.logger.debug(
                         "lean_code_actions fallback: could not read line text from %s: %s",
                         file_path,

--- a/src/lean_lsp_mcp/tools/goals.py
+++ b/src/lean_lsp_mcp/tools/goals.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Annotated, Literal, Optional
 
-from leanclient import LeanLSPClient
 from mcp.server.fastmcp import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -42,57 +41,63 @@ def goal(
     Omit column to see goals_before (line start) and goals_after (line end),
     showing how the tactic transforms the state. "no goals" = proof complete.
     """
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            client = lsp.client
+            rel_path = lsp.rel_path
+            content = client.get_file_content(rel_path)
+            lines = content.splitlines()
+
+            if line < 1 or line > len(lines):
+                raise server.LeanToolError(
+                    f"Line {line} out of range (file has {len(lines)} lines)"
+                )
+
+            line_context = lines[line - 1]
+
+            if column is None:
+                column_end = len(line_context)
+                column_start = next(
+                    (i for i, c in enumerate(line_context) if not c.isspace()), 0
+                )
+                goal_start = server._get_goal_response(
+                    client, rel_path, line - 1, column_start
+                )
+                server.check_lsp_response(goal_start, "get_goal", allow_none=True)
+                goal_end = server._get_goal_response(
+                    client, rel_path, line - 1, column_end
+                )
+                structured = format == "structured"
+                goals_before: list[str | StructuredGoal] = [
+                    server._goal_to_structured(g) if structured else g
+                    for g in server.extract_goals_list(goal_start)
+                ]
+                goals_after: list[str | StructuredGoal] = [
+                    server._goal_to_structured(g) if structured else g
+                    for g in server.extract_goals_list(goal_end)
+                ]
+
+                return GoalState(
+                    line_context=line_context,
+                    goals_before=goals_before,
+                    goals_after=goals_after,
+                )
+
+            goal_result = server._get_goal_response(
+                client, rel_path, line - 1, column - 1
+            )
+            server.check_lsp_response(goal_result, "get_goal", allow_none=True)
+            structured = format == "structured"
+            goals: list[str | StructuredGoal] = [
+                server._goal_to_structured(g) if structured else g
+                for g in server.extract_goals_list(goal_result)
+            ]
+            return GoalState(
+                line_context=line_context,
+                goals=goals,
+            )
+    except server.InvalidLeanFilePathError:
         server._raise_invalid_path(file_path)
-
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
-    content = client.get_file_content(rel_path)
-    lines = content.splitlines()
-
-    if line < 1 or line > len(lines):
-        raise server.LeanToolError(
-            f"Line {line} out of range (file has {len(lines)} lines)"
-        )
-
-    line_context = lines[line - 1]
-
-    if column is None:
-        column_end = len(line_context)
-        column_start = next(
-            (i for i, c in enumerate(line_context) if not c.isspace()), 0
-        )
-        goal_start = server._get_goal_response(client, rel_path, line - 1, column_start)
-        server.check_lsp_response(goal_start, "get_goal", allow_none=True)
-        goal_end = server._get_goal_response(client, rel_path, line - 1, column_end)
-        structured = format == "structured"
-        goals_before: list[str | StructuredGoal] = [
-            server._goal_to_structured(g) if structured else g
-            for g in server.extract_goals_list(goal_start)
-        ]
-        goals_after: list[str | StructuredGoal] = [
-            server._goal_to_structured(g) if structured else g
-            for g in server.extract_goals_list(goal_end)
-        ]
-
-        return GoalState(
-            line_context=line_context,
-            goals_before=goals_before,
-            goals_after=goals_after,
-        )
-    else:
-        goal_result = server._get_goal_response(client, rel_path, line - 1, column - 1)
-        server.check_lsp_response(goal_result, "get_goal", allow_none=True)
-        structured = format == "structured"
-        goals: list[str | StructuredGoal] = [
-            server._goal_to_structured(g) if structured else g
-            for g in server.extract_goals_list(goal_result)
-        ]
-        return GoalState(
-            line_context=line_context,
-            goals=goals,
-        )
 
 
 @server.mcp.tool(
@@ -115,30 +120,34 @@ def term_goal(
     ] = None,
 ) -> TermGoalState:
     """Get the expected type at a position."""
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            client = lsp.client
+            rel_path = lsp.rel_path
+            content = client.get_file_content(rel_path)
+            lines = content.splitlines()
+
+            if line < 1 or line > len(lines):
+                raise server.LeanToolError(
+                    f"Line {line} out of range (file has {len(lines)} lines)"
+                )
+
+            line_context = lines[line - 1]
+            if column is None:
+                column = max(len(line_context), 1)
+
+            term_goal_result = client.get_term_goal(rel_path, line - 1, column - 1)
+            server.check_lsp_response(
+                term_goal_result, "get_term_goal", allow_none=True
+            )
+            expected_type = None
+            if term_goal_result is not None:
+                rendered = term_goal_result.get("goal")
+                if rendered:
+                    expected_type = rendered.replace("```lean\n", "").replace(
+                        "\n```", ""
+                    )
+
+            return TermGoalState(line_context=line_context, expected_type=expected_type)
+    except server.InvalidLeanFilePathError:
         server._raise_invalid_path(file_path)
-
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
-    content = client.get_file_content(rel_path)
-    lines = content.splitlines()
-
-    if line < 1 or line > len(lines):
-        raise server.LeanToolError(
-            f"Line {line} out of range (file has {len(lines)} lines)"
-        )
-
-    line_context = lines[line - 1]
-    if column is None:
-        column = max(len(line_context), 1)
-
-    term_goal_result = client.get_term_goal(rel_path, line - 1, column - 1)
-    server.check_lsp_response(term_goal_result, "get_term_goal", allow_none=True)
-    expected_type = None
-    if term_goal_result is not None:
-        rendered = term_goal_result.get("goal")
-        if rendered:
-            expected_type = rendered.replace("```lean\n", "").replace("\n```", "")
-
-    return TermGoalState(line_context=line_context, expected_type=expected_type)

--- a/src/lean_lsp_mcp/tools/navigation.py
+++ b/src/lean_lsp_mcp/tools/navigation.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 import re
 from typing import Annotated, List
 
-from leanclient import LeanLSPClient
 from mcp.server.fastmcp import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from lean_lsp_mcp import server
-from lean_lsp_mcp.client_utils import get_path_policy
 from lean_lsp_mcp.models import (
     CompletionItem,
     CompletionsResult,
@@ -47,36 +45,37 @@ def hover(
     column: Annotated[int, Field(description="Column at START of identifier", ge=1)],
 ) -> HoverInfo:
     """Get type signature and docs for a symbol. Essential for understanding APIs."""
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            client = lsp.client
+            rel_path = lsp.rel_path
+            file_content = client.get_file_content(rel_path)
+            hover_info = client.get_hover(rel_path, line - 1, column - 1)
+            check_lsp_response(hover_info, "get_hover", allow_none=True)
+            if hover_info is None:
+                raise server.LeanToolError(
+                    f"No hover information at line {line}, column {column}"
+                )
+
+            # Get the symbol and the hover information
+            h_range = hover_info.get("range")
+            symbol = extract_range(file_content, h_range) or ""
+            info = hover_info["contents"].get(
+                "value", "No hover information available."
+            )
+            info = info.replace("```lean\n", "").replace("\n```", "").strip()
+
+            diagnostics = client.get_diagnostics(rel_path)
+            check_lsp_response(diagnostics, "get_diagnostics")
+            filtered = filter_diagnostics_by_position(diagnostics, line - 1, column - 1)
+
+            return HoverInfo(
+                symbol=symbol,
+                info=info,
+                diagnostics=server._to_diagnostic_messages(filtered),
+            )
+    except server.InvalidLeanFilePathError:
         server._raise_invalid_path(file_path)
-
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
-    file_content = client.get_file_content(rel_path)
-    hover_info = client.get_hover(rel_path, line - 1, column - 1)
-    check_lsp_response(hover_info, "get_hover", allow_none=True)
-    if hover_info is None:
-        raise server.LeanToolError(
-            f"No hover information at line {line}, column {column}"
-        )
-
-    # Get the symbol and the hover information
-    h_range = hover_info.get("range")
-    symbol = extract_range(file_content, h_range) or ""
-    info = hover_info["contents"].get("value", "No hover information available.")
-    info = info.replace("```lean\n", "").replace("\n```", "").strip()
-
-    # Add diagnostics if available
-    diagnostics = client.get_diagnostics(rel_path)
-    check_lsp_response(diagnostics, "get_diagnostics")
-    filtered = filter_diagnostics_by_position(diagnostics, line - 1, column - 1)
-
-    return HoverInfo(
-        symbol=symbol,
-        info=info,
-        diagnostics=server._to_diagnostic_messages(filtered),
-    )
 
 
 @server.mcp.tool(
@@ -98,60 +97,62 @@ def completions(
     max_completions: Annotated[int, Field(description="Max completions", ge=1)] = 32,
 ) -> CompletionsResult:
     """Get IDE autocompletions. Use on INCOMPLETE code (after `.` or partial name)."""
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
-        server._raise_invalid_path(file_path)
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            client = lsp.client
+            rel_path = lsp.rel_path
+            content = client.get_file_content(rel_path)
+            raw_completions = client.get_completions(rel_path, line - 1, column - 1)
+            check_lsp_response(raw_completions, "get_completions")
 
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
-    content = client.get_file_content(rel_path)
-    raw_completions = client.get_completions(rel_path, line - 1, column - 1)
-    check_lsp_response(raw_completions, "get_completions")
+            # Convert to CompletionItem models
+            items: List[CompletionItem] = []
+            for c in raw_completions:
+                if "label" not in c:
+                    continue
+                kind_int = c.get("kind")
+                kind_str = COMPLETION_KIND.get(kind_int) if kind_int else None
+                items.append(
+                    CompletionItem(
+                        label=c["label"],
+                        kind=kind_str,
+                        detail=c.get("detail"),
+                    )
+                )
 
-    # Convert to CompletionItem models
-    items: List[CompletionItem] = []
-    for c in raw_completions:
-        if "label" not in c:
-            continue
-        kind_int = c.get("kind")
-        kind_str = COMPLETION_KIND.get(kind_int) if kind_int else None
-        items.append(
-            CompletionItem(
-                label=c["label"],
-                kind=kind_str,
-                detail=c.get("detail"),
-            )
-        )
+            if not items:
+                return CompletionsResult(items=[])
 
-    if not items:
-        return CompletionsResult(items=[])
+            # Find the sort term: The last word/identifier before the cursor
+            lines = content.splitlines()
+            prefix = ""
+            if 0 < line <= len(lines):
+                text_before_cursor = lines[line - 1][: column - 1] if column > 0 else ""
+                if not text_before_cursor.endswith("."):
+                    prefix = re.split(r"[\s()\[\]{},:;.]+", text_before_cursor)[
+                        -1
+                    ].lower()
 
-    # Find the sort term: The last word/identifier before the cursor
-    lines = content.splitlines()
-    prefix = ""
-    if 0 < line <= len(lines):
-        text_before_cursor = lines[line - 1][: column - 1] if column > 0 else ""
-        if not text_before_cursor.endswith("."):
-            prefix = re.split(r"[\s()\[\]{},:;.]+", text_before_cursor)[-1].lower()
+            # Sort completions: prefix matches first, then contains, then alphabetical
+            if prefix:
 
-    # Sort completions: prefix matches first, then contains, then alphabetical
-    if prefix:
+                def sort_key(item: CompletionItem):
+                    label_lower = item.label.lower()
+                    if label_lower.startswith(prefix):
+                        return (0, label_lower)
+                    elif prefix in label_lower:
+                        return (1, label_lower)
+                    else:
+                        return (2, label_lower)
 
-        def sort_key(item: CompletionItem):
-            label_lower = item.label.lower()
-            if label_lower.startswith(prefix):
-                return (0, label_lower)
-            elif prefix in label_lower:
-                return (1, label_lower)
+                items.sort(key=sort_key)
             else:
-                return (2, label_lower)
+                items.sort(key=lambda x: x.label.lower())
 
-        items.sort(key=sort_key)
-    else:
-        items.sort(key=lambda x: x.label.lower())
-
-    # Truncate if too many results
-    return CompletionsResult(items=items[:max_completions])
+            # Truncate if too many results
+            return CompletionsResult(items=items[:max_completions])
+    except server.InvalidLeanFilePathError:
+        server._raise_invalid_path(file_path)
 
 
 @server.mcp.tool(
@@ -173,37 +174,37 @@ def declaration_file(
     ],
 ) -> DeclarationInfo:
     """Get file where a symbol is declared. Symbol must be present in file first."""
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
-        server._raise_invalid_path(file_path)
-
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
-    orig_file_content = client.get_file_content(rel_path)
-
-    # Find the first occurence of the symbol (line and column) in the file
-    position = find_start_position(orig_file_content, symbol)
-    if not position:
-        raise server.LeanToolError(
-            f"Symbol `{symbol}` (case sensitive) not found in file. Add it first."
-        )
-
-    declaration = client.get_declarations(
-        rel_path, position["line"], position["column"]
-    )
-
-    if len(declaration) == 0:
-        raise server.LeanToolError(f"No declaration available for `{symbol}`.")
-
-    # Load the declaration file
-    decl = declaration[0]
-    uri = decl.get("targetUri") or decl.get("uri")
-
     try:
-        policy = get_path_policy(ctx)
-        abs_path = policy.validate_path(client._uri_to_abs(uri))
-    except ValueError as exc:
-        raise server.LeanToolError(str(exc)) from exc
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            client = lsp.client
+            rel_path = lsp.rel_path
+            orig_file_content = client.get_file_content(rel_path)
+
+            # Find the first occurence of the symbol (line and column) in the file
+            position = find_start_position(orig_file_content, symbol)
+            if not position:
+                raise server.LeanToolError(
+                    f"Symbol `{symbol}` (case sensitive) not found in file. Add it first."
+                )
+
+            declaration = client.get_declarations(
+                rel_path, position["line"], position["column"]
+            )
+
+            if len(declaration) == 0:
+                raise server.LeanToolError(f"No declaration available for `{symbol}`.")
+
+            # Load the declaration file
+            decl = declaration[0]
+            uri = decl.get("targetUri") or decl.get("uri")
+
+            policy = lsp.path_policy
+            try:
+                abs_path = policy.validate_path(client._uri_to_abs(uri))
+            except ValueError as exc:
+                raise server.LeanToolError(str(exc)) from exc
+    except server.InvalidLeanFilePathError:
+        server._raise_invalid_path(file_path)
 
     if not abs_path.exists():
         raise server.LeanToolError(
@@ -236,49 +237,45 @@ def references(
     ],
 ) -> ReferencesResult:
     """Find all references to a symbol (including the declaration). Position cursor at the symbol."""
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            client = lsp.client
+            rel_path = lsp.rel_path
+            client.get_diagnostics(rel_path)
+
+            try:
+                raw_refs = client.get_references(
+                    rel_path, line - 1, column - 1, include_declaration=True
+                )
+            except Exception as e:
+                raise server.LeanToolError(f"Failed to get references: {e}")
+
+            if raw_refs is None:
+                raw_refs = []
+
+            items: List[ReferenceLocation] = []
+            policy = lsp.path_policy
+            for ref in raw_refs:
+                uri = ref.get("uri", "")
+                r = ref.get("range", {})
+                abs_path = ""
+                if uri:
+                    try:
+                        abs_path = policy.display_path(client._uri_to_abs(uri))
+                    except ValueError:
+                        continue
+                items.append(
+                    ReferenceLocation(
+                        file_path=abs_path,
+                        line=r.get("start", {}).get("line", 0) + 1,
+                        column=r.get("start", {}).get("character", 0) + 1,
+                        end_line=r.get("end", {}).get("line", 0) + 1,
+                        end_column=r.get("end", {}).get("character", 0) + 1,
+                    )
+                )
+
+            return ReferencesResult(items=items)
+    except server.InvalidLeanFilePathError:
         raise server.LeanToolError(
             "Invalid Lean file path: Unable to start LSP server or load file"
         )
-
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
-    # Ensure file is elaborated before querying references
-    client.get_diagnostics(rel_path)
-
-    try:
-        raw_refs = client.get_references(
-            rel_path, line - 1, column - 1, include_declaration=True
-        )
-    except Exception as e:
-        raise server.LeanToolError(f"Failed to get references: {e}")
-
-    if raw_refs is None:
-        raw_refs = []
-
-    items: List[ReferenceLocation] = []
-    try:
-        policy = get_path_policy(ctx)
-    except ValueError as exc:
-        raise server.LeanToolError(str(exc)) from exc
-    for ref in raw_refs:
-        uri = ref.get("uri", "")
-        r = ref.get("range", {})
-        abs_path = ""
-        if uri:
-            try:
-                abs_path = policy.display_path(client._uri_to_abs(uri))
-            except ValueError:
-                continue
-        items.append(
-            ReferenceLocation(
-                file_path=abs_path,
-                line=r.get("start", {}).get("line", 0) + 1,
-                column=r.get("start", {}).get("character", 0) + 1,
-                end_line=r.get("end", {}).get("line", 0) + 1,
-                end_column=r.get("end", {}).get("character", 0) + 1,
-            )
-        )
-
-    return ReferencesResult(items=items)

--- a/src/lean_lsp_mcp/tools/search.py
+++ b/src/lean_lsp_mcp/tools/search.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Annotated, List, Literal, Optional
 
 import orjson
-from leanclient import LeanLSPClient
 from mcp.server.fastmcp import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -313,13 +312,12 @@ async def state_search(
     num_results: Annotated[int, Field(description="Max results", ge=1)] = 5,
 ) -> StateSearchResults:
     """Find lemmas to close the goal at a position. Searches premise-search.com."""
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            rel_path = lsp.rel_path
+            goal = lsp.client.get_goal(rel_path, line - 1, column - 1)
+    except server.InvalidLeanFilePathError:
         server._raise_invalid_path(file_path)
-
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
-    goal = client.get_goal(rel_path, line - 1, column - 1)
 
     if not goal or not goal.get("goals"):
         raise server.LeanToolError(
@@ -372,13 +370,12 @@ async def hammer_premise(
 
     Returns lemma names to try with `simp only [...]`, `aesop`, or as hints.
     """
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            rel_path = lsp.rel_path
+            goal = lsp.client.get_goal(rel_path, line - 1, column - 1)
+    except server.InvalidLeanFilePathError:
         server._raise_invalid_path(file_path)
-
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
-    goal = client.get_goal(rel_path, line - 1, column - 1)
 
     if not goal or not goal.get("goals"):
         raise server.LeanToolError(

--- a/src/lean_lsp_mcp/tools/search.py
+++ b/src/lean_lsp_mcp/tools/search.py
@@ -37,6 +37,16 @@ class LocalSearchError(Exception):
     pass
 
 
+def _get_goal_for_remote_search(
+    ctx: Context, file_path: str, line: int, column: int
+) -> dict:
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            return lsp.client.get_goal(lsp.rel_path, line - 1, column - 1)
+    except server.InvalidLeanFilePathError:
+        server._raise_invalid_path(file_path)
+
+
 @server.mcp.tool(
     "lean_local_search",
     annotations=ToolAnnotations(
@@ -312,12 +322,9 @@ async def state_search(
     num_results: Annotated[int, Field(description="Max results", ge=1)] = 5,
 ) -> StateSearchResults:
     """Find lemmas to close the goal at a position. Searches premise-search.com."""
-    try:
-        with server.lsp_client_for_file(ctx, file_path) as lsp:
-            rel_path = lsp.rel_path
-            goal = lsp.client.get_goal(rel_path, line - 1, column - 1)
-    except server.InvalidLeanFilePathError:
-        server._raise_invalid_path(file_path)
+    goal = await asyncio.to_thread(
+        _get_goal_for_remote_search, ctx, file_path, line, column
+    )
 
     if not goal or not goal.get("goals"):
         raise server.LeanToolError(
@@ -370,12 +377,9 @@ async def hammer_premise(
 
     Returns lemma names to try with `simp only [...]`, `aesop`, or as hints.
     """
-    try:
-        with server.lsp_client_for_file(ctx, file_path) as lsp:
-            rel_path = lsp.rel_path
-            goal = lsp.client.get_goal(rel_path, line - 1, column - 1)
-    except server.InvalidLeanFilePathError:
-        server._raise_invalid_path(file_path)
+    goal = await asyncio.to_thread(
+        _get_goal_for_remote_search, ctx, file_path, line, column
+    )
 
     if not goal or not goal.get("goals"):
         raise server.LeanToolError(

--- a/src/lean_lsp_mcp/tools/search.py
+++ b/src/lean_lsp_mcp/tools/search.py
@@ -39,7 +39,7 @@ class LocalSearchError(Exception):
 
 def _get_goal_for_remote_search(
     ctx: Context, file_path: str, line: int, column: int
-) -> dict:
+) -> dict | None:
     try:
         with server.lsp_client_for_file(ctx, file_path) as lsp:
             return lsp.client.get_goal(lsp.rel_path, line - 1, column - 1)

--- a/src/lean_lsp_mcp/tools/widgets.py
+++ b/src/lean_lsp_mcp/tools/widgets.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from leanclient import LeanLSPClient
 from mcp.server.fastmcp import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -29,14 +28,13 @@ def get_widgets(
     column: Annotated[int, Field(description="Column number (1-indexed)", ge=1)],
 ) -> WidgetsResult:
     """Get panel widgets at a position (proof visualizations, #html, custom widgets). Returns raw widget data - may be large."""
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            rel_path = lsp.rel_path
+            widgets = lsp.client.get_widgets(rel_path, line - 1, column - 1)
+            return WidgetsResult(widgets=widgets)
+    except server.InvalidLeanFilePathError:
         server._raise_invalid_path(file_path)
-
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
-    widgets = client.get_widgets(rel_path, line - 1, column - 1)
-    return WidgetsResult(widgets=widgets)
 
 
 @server.mcp.tool(
@@ -56,13 +54,12 @@ def get_widget_source(
     ],
 ) -> WidgetSourceResult:
     """Get JavaScript source of a widget by hash. Useful for understanding custom widget rendering logic. Returns full JS module - may be large."""
-    rel_path = server.setup_client_for_file(ctx, file_path)
-    if not rel_path:
+    try:
+        with server.lsp_client_for_file(ctx, file_path) as lsp:
+            rel_path = lsp.rel_path
+            source = lsp.client.get_widget_source(
+                rel_path, 0, 0, {"javascriptHash": javascript_hash}
+            )
+            return WidgetSourceResult(source=source)
+    except server.InvalidLeanFilePathError:
         server._raise_invalid_path(file_path)
-
-    client: LeanLSPClient = ctx.request_context.lifespan_context.client
-    client.open_file(rel_path)
-    source = client.get_widget_source(
-        rel_path, 0, 0, {"javascriptHash": javascript_hash}
-    )
-    return WidgetSourceResult(source=source)

--- a/tests/helpers/lsp.py
+++ b/tests/helpers/lsp.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+import types
+
+
+@contextmanager
+def fake_lsp_file_operation(
+    client,
+    rel_path: str = "Foo.lean",
+    project_path: Path | None = None,
+    path_policy=None,
+) -> Iterator[types.SimpleNamespace]:
+    if hasattr(client, "open_file"):
+        client.open_file(rel_path)
+    yield types.SimpleNamespace(
+        client=client,
+        rel_path=rel_path,
+        project_path=project_path or Path("/tmp/proj"),
+        path_policy=path_policy
+        or types.SimpleNamespace(validate_path=lambda path: path),
+    )

--- a/tests/unit/test_build_progress.py
+++ b/tests/unit/test_build_progress.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from lean_lsp_mcp import client_utils
 from lean_lsp_mcp.server import lsp_build
 
 
@@ -239,8 +240,9 @@ async def test_lsp_build_continues_when_client_close_fails(
     """Pre-build client close failure is logged and does not abort the build."""
     project, ctx, _cache_proc, build_proc = build_mocks
     failing_client = _FailingClient()
-    failing_client.project_path = tmp_path / "old-proj"
+    failing_client.project_path = project
     ctx.request_context.lifespan_context.client = failing_client
+    client_utils.replace_shared_client(project, failing_client)
 
     build_proc.stdout.read = make_read(b"[0/1] Built\nDone\n")
     patch_build.side_effect = [build_proc]

--- a/tests/unit/test_client_utils.py
+++ b/tests/unit/test_client_utils.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import os
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Event
 
 import pytest
 
+import lean_lsp_mcp.client_utils as client_utils
 from lean_lsp_mcp.client_utils import (
     CLIENT_LOCK,
     bind_lean_project_path,
     close_shared_client,
+    lsp_client_for_file,
     replace_shared_client,
     resolve_file_path,
     set_build_in_progress,
@@ -32,9 +35,13 @@ class _MockLeanClient:
         self.project_path = project_path
         self.process = _MockProcess()
         self.closed = False
+        self.opened_files: list[str] = []
 
     def close(self) -> None:
         self.closed = True
+
+    def open_file(self, path: str) -> None:
+        self.opened_files.append(path)
 
 
 class _FailingCloseClient(_MockLeanClient):
@@ -329,6 +336,130 @@ def test_startup_client_serializes_concurrent_calls(
 
     assert len(patched_clients) == 1
     assert ctx.request_context.lifespan_context.client is patched_clients[0]
+
+
+def test_lsp_client_for_file_serializes_same_project_operations(
+    tmp_path: Path, patched_clients: list[_MockLeanClient]
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    file1 = project / "File1.lean"
+    file1.write_text("theorem a : True := by trivial")
+    file2 = project / "File2.lean"
+    file2.write_text("theorem b : True := by trivial")
+    ctx1 = _Context(_LifespanContext(project, None))
+    ctx2 = _Context(_LifespanContext(project, None))
+    first_entered = Event()
+    release_first = Event()
+    second_entered = Event()
+
+    def _hold_first_operation() -> str:
+        with lsp_client_for_file(ctx1, str(file1)) as op:
+            first_entered.set()
+            assert not second_entered.wait(0.05)
+            release_first.wait(timeout=2)
+            return op.rel_path
+
+    def _enter_second_operation() -> str:
+        first_entered.wait(timeout=2)
+        with lsp_client_for_file(ctx2, str(file2)) as op:
+            second_entered.set()
+            return op.rel_path
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(_hold_first_operation)
+        second = executor.submit(_enter_second_operation)
+        assert first_entered.wait(timeout=2)
+        assert not second_entered.wait(0.1)
+        release_first.set()
+        assert first.result(timeout=2) == "File1.lean"
+        assert second.result(timeout=2) == "File2.lean"
+
+    assert len(patched_clients) == 1
+
+
+def test_runtime_cap_waits_for_active_project_to_be_evictable(
+    tmp_path: Path,
+    patched_clients: list[_MockLeanClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_utils, "_MAX_SHARED_CLIENTS", 1)
+    project1 = _make_project(tmp_path / "proj1")
+    file1 = project1 / "File1.lean"
+    file1.write_text("theorem a : True := by trivial")
+    project2 = _make_project(tmp_path / "proj2")
+    file2 = project2 / "File2.lean"
+    file2.write_text("theorem b : True := by trivial")
+    ctx1 = _Context(_LifespanContext(project1, None))
+    ctx2 = _Context(_LifespanContext(project2, None))
+    first_entered = Event()
+    release_first = Event()
+    second_entered = Event()
+
+    def _hold_first_operation() -> str:
+        with lsp_client_for_file(ctx1, str(file1)) as op:
+            first_entered.set()
+            assert not second_entered.wait(0.05)
+            release_first.wait(timeout=2)
+            return op.rel_path
+
+    def _enter_second_operation() -> str:
+        first_entered.wait(timeout=2)
+        with lsp_client_for_file(ctx2, str(file2)) as op:
+            second_entered.set()
+            return op.rel_path
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(_hold_first_operation)
+        second = executor.submit(_enter_second_operation)
+        assert first_entered.wait(timeout=2)
+        assert not second_entered.wait(0.1)
+        release_first.set()
+        assert first.result(timeout=2) == "File1.lean"
+        assert second.result(timeout=2) == "File2.lean"
+
+    assert len(patched_clients) == 2
+    assert patched_clients[0].closed
+    assert not patched_clients[1].closed
+
+
+def test_build_detach_waits_for_active_operation(
+    tmp_path: Path, patched_clients: list[_MockLeanClient]
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    file_path = project / "File.lean"
+    file_path.write_text("theorem a : True := by trivial")
+    ctx = _Context(_LifespanContext(project, None))
+    runtime = client_utils.get_project_runtime(project)
+    operation_entered = Event()
+    release_operation = Event()
+    build_detached = Event()
+
+    def _hold_operation() -> str:
+        with lsp_client_for_file(ctx, str(file_path)) as op:
+            operation_entered.set()
+            assert not build_detached.wait(0.05)
+            release_operation.wait(timeout=2)
+            return op.rel_path
+
+    def _detach_for_build() -> None:
+        operation_entered.wait(timeout=2)
+        runtime.detach_for_build()
+        build_detached.set()
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            operation = executor.submit(_hold_operation)
+            build = executor.submit(_detach_for_build)
+            assert operation_entered.wait(timeout=2)
+            assert not build_detached.wait(0.1)
+            release_operation.set()
+            assert operation.result(timeout=2) == "File.lean"
+            assert build.result(timeout=2) is None
+
+        assert build_detached.is_set()
+        assert patched_clients[0].closed
+    finally:
+        runtime.clear_build_in_progress()
 
 
 def test_build_in_progress_blocks_only_same_project(

--- a/tests/unit/test_client_utils.py
+++ b/tests/unit/test_client_utils.py
@@ -54,6 +54,28 @@ class _FailingCloseClient(_MockLeanClient):
         raise PermissionError("operation not permitted")
 
 
+class _Future:
+    def __init__(self, exc: BaseException) -> None:
+        self.exc = exc
+        self.observed = False
+        self.callback = None
+
+    def add_done_callback(self, callback) -> None:
+        self.callback = callback
+
+    def exception(self) -> BaseException:
+        self.observed = True
+        return self.exc
+
+
+class _FutureClient:
+    def __init__(self, future) -> None:
+        self.future = future
+
+    def _send_request_async(self, _method: str, _params: dict):
+        return self.future
+
+
 class _LifespanContext:
     def __init__(
         self,
@@ -483,6 +505,25 @@ def test_build_in_progress_blocks_only_same_project(
     finally:
         with CLIENT_LOCK:
             set_build_in_progress(project1, False)
+
+
+def test_wait_for_diagnostics_file_worker_shutdown_future_is_observed() -> None:
+    future = _Future(
+        Exception(
+            "LSP Error: {'code': -32801, 'message': 'The file worker for "
+            "file:///Test.lean has been terminated.'}"
+        )
+    )
+    client = _FutureClient(future)
+
+    client_utils._install_wait_for_diagnostics_drain(client)
+    wrapped = client._send_request_async("textDocument/waitForDiagnostics", {})
+    assert wrapped is future
+
+    assert future.callback is not None
+    future.callback(future)
+
+    assert future.observed
 
 
 def test_resolve_file_path_uses_project_root_for_relative(tmp_path: Path) -> None:

--- a/tests/unit/test_code_actions_fallback.py
+++ b/tests/unit/test_code_actions_fallback.py
@@ -11,12 +11,12 @@ unreproducible in the live integration test).
 from __future__ import annotations
 
 import types
-from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 
 from lean_lsp_mcp import server as srv
+from tests.helpers.lsp import fake_lsp_file_operation
 
 
 class _Client:
@@ -57,17 +57,6 @@ class _Ctx:
         self.request_context = _ReqCtx(client)
 
 
-@contextmanager
-def _fake_lsp_file(client, rel_path):
-    client.open_file(rel_path)
-    yield types.SimpleNamespace(
-        client=client,
-        rel_path=rel_path,
-        project_path=Path("/tmp"),
-        path_policy=types.SimpleNamespace(validate_path=lambda path: path),
-    )
-
-
 @pytest.fixture()
 def lean_file(tmp_path: Path) -> Path:
     p = tmp_path / "Fallback.lean"
@@ -87,7 +76,7 @@ def test_fallback_fires_when_no_diagnostic_yet_actions_exist_at_line_range(
     fake_action = {"title": "Try this: simp", "edit": {"documentChanges": []}}
     client = _Client({range_with_action: [fake_action]})
     monkeypatch.setattr(
-        srv, "lsp_client_for_file", lambda _c, p: _fake_lsp_file(client, p)
+        srv, "lsp_client_for_file", lambda _c, p: fake_lsp_file_operation(client, p)
     )
     monkeypatch.setattr(srv, "resolve_file_path", lambda c, p: lean_file)
 
@@ -121,7 +110,7 @@ def test_fallback_uses_utf16_length_for_end_column(
     fake_action = {"title": "Try this: trivial", "edit": {"documentChanges": []}}
     client = _Client({range_with_action: [fake_action]})
     monkeypatch.setattr(
-        srv, "lsp_client_for_file", lambda _c, p: _fake_lsp_file(client, p)
+        srv, "lsp_client_for_file", lambda _c, p: fake_lsp_file_operation(client, p)
     )
     monkeypatch.setattr(srv, "resolve_file_path", lambda c, p: f)
 
@@ -164,7 +153,7 @@ def test_fallback_swallows_resolve_failures_but_logs(
 
     client = _Client({})
     monkeypatch.setattr(
-        srv, "lsp_client_for_file", lambda _c, p: _fake_lsp_file(client, p)
+        srv, "lsp_client_for_file", lambda _c, p: fake_lsp_file_operation(client, p)
     )
 
     def _raise(_c, _p):

--- a/tests/unit/test_code_actions_fallback.py
+++ b/tests/unit/test_code_actions_fallback.py
@@ -11,6 +11,7 @@ unreproducible in the live integration test).
 from __future__ import annotations
 
 import types
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -56,6 +57,17 @@ class _Ctx:
         self.request_context = _ReqCtx(client)
 
 
+@contextmanager
+def _fake_lsp_file(client, rel_path):
+    client.open_file(rel_path)
+    yield types.SimpleNamespace(
+        client=client,
+        rel_path=rel_path,
+        project_path=Path("/tmp"),
+        path_policy=types.SimpleNamespace(validate_path=lambda path: path),
+    )
+
+
 @pytest.fixture()
 def lean_file(tmp_path: Path) -> Path:
     p = tmp_path / "Fallback.lean"
@@ -74,7 +86,9 @@ def test_fallback_fires_when_no_diagnostic_yet_actions_exist_at_line_range(
     range_with_action = (3, 0, 3, 7)
     fake_action = {"title": "Try this: simp", "edit": {"documentChanges": []}}
     client = _Client({range_with_action: [fake_action]})
-    monkeypatch.setattr(srv, "setup_client_for_file", lambda c, p: p)
+    monkeypatch.setattr(
+        srv, "lsp_client_for_file", lambda _c, p: _fake_lsp_file(client, p)
+    )
     monkeypatch.setattr(srv, "resolve_file_path", lambda c, p: lean_file)
 
     result = srv.code_actions(_Ctx(client), file_path=str(lean_file), line=4)
@@ -106,7 +120,9 @@ def test_fallback_uses_utf16_length_for_end_column(
     range_with_action = (3, 0, 3, expected_end_utf16)
     fake_action = {"title": "Try this: trivial", "edit": {"documentChanges": []}}
     client = _Client({range_with_action: [fake_action]})
-    monkeypatch.setattr(srv, "setup_client_for_file", lambda c, p: p)
+    monkeypatch.setattr(
+        srv, "lsp_client_for_file", lambda _c, p: _fake_lsp_file(client, p)
+    )
     monkeypatch.setattr(srv, "resolve_file_path", lambda c, p: f)
 
     result = srv.code_actions(_Ctx(client), file_path=str(f), line=4)
@@ -147,7 +163,9 @@ def test_fallback_swallows_resolve_failures_but_logs(
     import logging
 
     client = _Client({})
-    monkeypatch.setattr(srv, "setup_client_for_file", lambda c, p: p)
+    monkeypatch.setattr(
+        srv, "lsp_client_for_file", lambda _c, p: _fake_lsp_file(client, p)
+    )
 
     def _raise(_c, _p):
         # UnicodeDecodeError requires positional args; construct it carefully.

--- a/tests/unit/test_references.py
+++ b/tests/unit/test_references.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import types
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
+from lean_lsp_mcp import client_utils
 from lean_lsp_mcp import server
 from lean_lsp_mcp.models import ReferencesResult
 
@@ -42,11 +43,12 @@ def _make_raw_ref(
     }
 
 
-@patch("lean_lsp_mcp.server.setup_client_for_file", return_value="Test.lean")
-def test_references_parses_lsp_response(mock_setup: MagicMock, tmp_path: Path) -> None:
+def test_references_parses_lsp_response(tmp_path: Path) -> None:
     project = _make_project(tmp_path / "proj")
     lean_file = project / "Test.lean"
+    lean_file.write_text("theorem test : True := by trivial\n")
     client = MagicMock()
+    client.process = None
     client._uri_to_abs.return_value = lean_file
     client.get_references.return_value = [
         _make_raw_ref(lean_file.as_uri(), 2, 4, 2, 12),
@@ -55,6 +57,7 @@ def test_references_parses_lsp_response(mock_setup: MagicMock, tmp_path: Path) -
     ]
 
     ctx = _make_ctx(client, project)
+    client_utils.replace_shared_client(project, client)
     result = server.references(ctx, str(lean_file), 3, 5)
 
     assert isinstance(result, ReferencesResult)
@@ -69,22 +72,23 @@ def test_references_parses_lsp_response(mock_setup: MagicMock, tmp_path: Path) -
     )
 
 
-@patch("lean_lsp_mcp.server.setup_client_for_file", return_value="Test.lean")
-def test_references_empty_result(mock_setup: MagicMock, tmp_path: Path) -> None:
+def test_references_empty_result(tmp_path: Path) -> None:
     project = _make_project(tmp_path / "proj")
     lean_file = project / "Test.lean"
+    lean_file.write_text("theorem test : True := by trivial\n")
     client = MagicMock()
+    client.process = None
     client.get_references.return_value = None
 
     ctx = _make_ctx(client, project)
+    client_utils.replace_shared_client(project, client)
     result = server.references(ctx, str(lean_file), 1, 1)
 
     assert isinstance(result, ReferencesResult)
     assert len(result.items) == 0
 
 
-@patch("lean_lsp_mcp.server.setup_client_for_file", return_value=None)
-def test_references_invalid_path(mock_setup: MagicMock, tmp_path: Path) -> None:
+def test_references_invalid_path(tmp_path: Path) -> None:
     client = MagicMock()
     project = _make_project(tmp_path / "proj")
     ctx = _make_ctx(client, project)
@@ -93,14 +97,16 @@ def test_references_invalid_path(mock_setup: MagicMock, tmp_path: Path) -> None:
         server.references(ctx, "/nonexistent/Test.lean", 1, 1)
 
 
-@patch("lean_lsp_mcp.server.setup_client_for_file", return_value="Test.lean")
-def test_references_lsp_exception(mock_setup: MagicMock, tmp_path: Path) -> None:
+def test_references_lsp_exception(tmp_path: Path) -> None:
     project = _make_project(tmp_path / "proj")
     lean_file = project / "Test.lean"
+    lean_file.write_text("theorem test : True := by trivial\n")
     client = MagicMock()
+    client.process = None
     client.get_references.side_effect = RuntimeError("LSP timeout")
 
     ctx = _make_ctx(client, project)
+    client_utils.replace_shared_client(project, client)
 
     with pytest.raises(server.LeanToolError, match="Failed to get references"):
         server.references(ctx, str(lean_file), 1, 1)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import contextmanager
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 import importlib
 import json
@@ -14,6 +13,7 @@ import pytest
 from lean_lsp_mcp import client_utils
 from lean_lsp_mcp import server
 from lean_lsp_mcp.models import DiagnosticSeverity
+from tests.helpers.lsp import fake_lsp_file_operation
 
 
 class DummyClient:
@@ -85,20 +85,6 @@ def _make_dependency(project: Path, dep_root: Path) -> Path:
     dep_link.parent.mkdir(parents=True)
     dep_link.symlink_to(dep_root, target_is_directory=True)
     return dep_file
-
-
-@contextmanager
-def _fake_lsp_file(
-    client, rel_path: str = "Foo.lean", project_path: Path | None = None
-):
-    if hasattr(client, "open_file"):
-        client.open_file(rel_path)
-    yield types.SimpleNamespace(
-        client=client,
-        rel_path=rel_path,
-        project_path=project_path or Path("/tmp/proj"),
-        path_policy=types.SimpleNamespace(validate_path=lambda path: path),
-    )
 
 
 @pytest.mark.asyncio
@@ -902,7 +888,7 @@ def test_diagnostic_messages_passes_severity_to_process(
     monkeypatch.setattr(
         server,
         "lsp_client_for_file",
-        lambda _ctx, _path: _fake_lsp_file(fake_client, "Foo.lean"),
+        lambda _ctx, _path: fake_lsp_file_operation(fake_client, "Foo.lean"),
     )
 
     server.diagnostic_messages(
@@ -943,7 +929,7 @@ def test_diagnostic_messages_default_severity_is_none(
     monkeypatch.setattr(
         server,
         "lsp_client_for_file",
-        lambda _ctx, _path: _fake_lsp_file(fake_client, "Foo.lean"),
+        lambda _ctx, _path: fake_lsp_file_operation(fake_client, "Foo.lean"),
     )
 
     server.diagnostic_messages(ctx=ctx, file_path="/abs/Foo.lean")
@@ -986,7 +972,7 @@ def test_goal_retries_after_cold_file_timeout(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(
         server,
         "lsp_client_for_file",
-        lambda _ctx, _path: _fake_lsp_file(fake_client, "GoalSample.lean"),
+        lambda _ctx, _path: fake_lsp_file_operation(fake_client, "GoalSample.lean"),
     )
 
     result = server.goal(ctx, file_path="/abs/GoalSample.lean", line=4, column=3)
@@ -1016,7 +1002,7 @@ def test_goal_structured_format_accepts_structured_goals(
     monkeypatch.setattr(
         server,
         "lsp_client_for_file",
-        lambda _ctx, _path: _fake_lsp_file(fake_client, "GoalSample.lean"),
+        lambda _ctx, _path: fake_lsp_file_operation(fake_client, "GoalSample.lean"),
     )
 
     result = server.goal(
@@ -1068,7 +1054,7 @@ def test_goal_returns_no_goals_without_retry(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(
         server,
         "lsp_client_for_file",
-        lambda _ctx, _path: _fake_lsp_file(fake_client, "GoalSample.lean"),
+        lambda _ctx, _path: fake_lsp_file_operation(fake_client, "GoalSample.lean"),
     )
 
     result = server.goal(ctx, file_path="/abs/GoalSample.lean", line=4, column=3)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 import importlib
 import json
@@ -86,6 +87,20 @@ def _make_dependency(project: Path, dep_root: Path) -> Path:
     return dep_file
 
 
+@contextmanager
+def _fake_lsp_file(
+    client, rel_path: str = "Foo.lean", project_path: Path | None = None
+):
+    if hasattr(client, "open_file"):
+        client.open_file(rel_path)
+    yield types.SimpleNamespace(
+        client=client,
+        rel_path=rel_path,
+        project_path=project_path or Path("/tmp/proj"),
+        path_policy=types.SimpleNamespace(validate_path=lambda path: path),
+    )
+
+
 @pytest.mark.asyncio
 async def test_app_lifespan_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LEAN_LOG_LEVEL", raising=False)
@@ -143,14 +158,11 @@ async def test_app_lifespan_does_not_close_shared_client(
 def test_close_shared_client_closes_client() -> None:
     """close_shared_client() closes the shared singleton and resets state."""
     dummy = DummyClient()
-    client_utils._shared_clients[Path("/tmp/proj")] = dummy
+    client_utils.replace_shared_client(Path("/tmp/proj"), dummy)
 
-    try:
-        client_utils.close_shared_client()
-        assert dummy.closed_calls == 1
-        assert client_utils._shared_clients == {}
-    finally:
-        client_utils._shared_clients.clear()
+    client_utils.close_shared_client()
+    assert dummy.closed_calls == 1
+    assert client_utils._project_runtimes == {}
 
 
 def test_close_shared_client_suppresses_error() -> None:
@@ -165,19 +177,16 @@ def test_close_shared_client_suppresses_error() -> None:
             raise PermissionError("operation not permitted")
 
     dummy = _FailingCloseClient()
-    client_utils._shared_clients[Path("/tmp/proj")] = dummy
+    client_utils.replace_shared_client(Path("/tmp/proj"), dummy)
 
-    try:
-        client_utils.close_shared_client()  # should not raise
-        assert dummy.close_calls == 1
-        assert client_utils._shared_clients == {}
-    finally:
-        client_utils._shared_clients.clear()
+    client_utils.close_shared_client()  # should not raise
+    assert dummy.close_calls == 1
+    assert client_utils._project_runtimes == {}
 
 
 def test_close_shared_client_noop_when_none() -> None:
     """close_shared_client() is safe to call when no client exists."""
-    client_utils._shared_clients.clear()
+    client_utils._project_runtimes.clear()
     client_utils.close_shared_client()  # should not raise
 
 
@@ -560,7 +569,7 @@ def test_multi_attempt_force_reopens_after_restore(
     ctx = _make_ctx(lean_project_path=project)
     ctx.request_context.lifespan_context.client = fake_client
 
-    monkeypatch.setattr(server, "setup_client_for_file", lambda _ctx, _path: "Foo.lean")
+    client_utils.replace_shared_client(project, fake_client)
     monkeypatch.setattr(server, "get_file_contents", lambda _path: "original")
 
     result = server._multi_attempt_lsp(ctx, str(target), line=1, snippets=[])
@@ -584,7 +593,7 @@ def test_multi_attempt_restore_falls_back_to_disk_on_buffer_read_failure(
     ctx = _make_ctx(lean_project_path=project)
     ctx.request_context.lifespan_context.client = fake_client
 
-    monkeypatch.setattr(server, "setup_client_for_file", lambda _ctx, _path: "Foo.lean")
+    client_utils.replace_shared_client(project, fake_client)
     monkeypatch.setattr(server, "get_file_contents", lambda _path: "disk-content")
 
     result = server._multi_attempt_lsp(ctx, str(target), line=1, snippets=[])
@@ -598,6 +607,7 @@ def test_declaration_file_sanitizes_dependency_path(
 ) -> None:
     project = _make_project(tmp_path / "proj")
     dep_file = _make_dependency(project, tmp_path / "deps" / "mathlib")
+    (project / "Main.lean").write_text("dep\n")
 
     class FakeClient:
         def open_file(self, _path: str) -> None:
@@ -615,8 +625,8 @@ def test_declaration_file_sanitizes_dependency_path(
 
     ctx = _make_ctx(lean_project_path=project)
     ctx.request_context.lifespan_context.client = FakeClient()
-    monkeypatch.setattr(
-        server, "setup_client_for_file", lambda _ctx, _path: "Main.lean"
+    client_utils.replace_shared_client(
+        project, ctx.request_context.lifespan_context.client
     )
 
     result = server.declaration_file(
@@ -632,6 +642,7 @@ def test_references_sanitize_paths_and_skip_outside_policy(
 ) -> None:
     project = _make_project(tmp_path / "proj")
     dep_file = _make_dependency(project, tmp_path / "deps" / "mathlib")
+    (project / "Main.lean").write_text("dep\n")
     outside_file = tmp_path / "outside" / "Leak.lean"
     outside_file.parent.mkdir(parents=True)
     outside_file.write_text("def leak : Nat := 0\n")
@@ -673,8 +684,8 @@ def test_references_sanitize_paths_and_skip_outside_policy(
 
     ctx = _make_ctx(lean_project_path=project)
     ctx.request_context.lifespan_context.client = FakeClient()
-    monkeypatch.setattr(
-        server, "setup_client_for_file", lambda _ctx, _path: "Main.lean"
+    client_utils.replace_shared_client(
+        project, ctx.request_context.lifespan_context.client
     )
 
     result = server.references(
@@ -884,10 +895,15 @@ def test_diagnostic_messages_passes_severity_to_process(
             return FakeDiagResult()
 
     monkeypatch.setattr(server, "_process_diagnostics", fake_process)
-    monkeypatch.setattr(server, "setup_client_for_file", lambda _ctx, _path: "Foo.lean")
 
     ctx = _make_ctx()
-    ctx.request_context.lifespan_context.client = FakeClient()
+    fake_client = FakeClient()
+    ctx.request_context.lifespan_context.client = fake_client
+    monkeypatch.setattr(
+        server,
+        "lsp_client_for_file",
+        lambda _ctx, _path: _fake_lsp_file(fake_client, "Foo.lean"),
+    )
 
     server.diagnostic_messages(
         ctx=ctx, file_path="/abs/Foo.lean", severity=DiagnosticSeverity.warning
@@ -920,10 +936,15 @@ def test_diagnostic_messages_default_severity_is_none(
             return FakeDiagResult()
 
     monkeypatch.setattr(server, "_process_diagnostics", fake_process)
-    monkeypatch.setattr(server, "setup_client_for_file", lambda _ctx, _path: "Foo.lean")
 
     ctx = _make_ctx()
-    ctx.request_context.lifespan_context.client = FakeClient()
+    fake_client = FakeClient()
+    ctx.request_context.lifespan_context.client = fake_client
+    monkeypatch.setattr(
+        server,
+        "lsp_client_for_file",
+        lambda _ctx, _path: _fake_lsp_file(fake_client, "Foo.lean"),
+    )
 
     server.diagnostic_messages(ctx=ctx, file_path="/abs/Foo.lean")
 
@@ -959,13 +980,14 @@ def test_goal_retries_after_cold_file_timeout(monkeypatch: pytest.MonkeyPatch) -
             self.diagnostic_calls.append((path, inactivity_timeout))
             return types.SimpleNamespace(diagnostics=[], success=True)
 
-    monkeypatch.setattr(
-        server, "setup_client_for_file", lambda _ctx, _path: "GoalSample.lean"
-    )
-
     ctx = _make_ctx()
     fake_client = FakeClient()
     ctx.request_context.lifespan_context.client = fake_client
+    monkeypatch.setattr(
+        server,
+        "lsp_client_for_file",
+        lambda _ctx, _path: _fake_lsp_file(fake_client, "GoalSample.lean"),
+    )
 
     result = server.goal(ctx, file_path="/abs/GoalSample.lean", line=4, column=3)
 
@@ -988,12 +1010,14 @@ def test_goal_structured_format_accepts_structured_goals(
         def get_goal(self, _path: str, _line: int, _column: int) -> dict:
             return {"goals": ["x : Nat\nh : x = 0\n⊢ x = 0"]}
 
-    monkeypatch.setattr(
-        server, "setup_client_for_file", lambda _ctx, _path: "GoalSample.lean"
-    )
-
     ctx = _make_ctx()
-    ctx.request_context.lifespan_context.client = FakeClient()
+    fake_client = FakeClient()
+    ctx.request_context.lifespan_context.client = fake_client
+    monkeypatch.setattr(
+        server,
+        "lsp_client_for_file",
+        lambda _ctx, _path: _fake_lsp_file(fake_client, "GoalSample.lean"),
+    )
 
     result = server.goal(
         ctx,
@@ -1038,13 +1062,14 @@ def test_goal_returns_no_goals_without_retry(monkeypatch: pytest.MonkeyPatch) ->
             self.diagnostic_calls += 1
             return types.SimpleNamespace(diagnostics=[], success=True)
 
-    monkeypatch.setattr(
-        server, "setup_client_for_file", lambda _ctx, _path: "GoalSample.lean"
-    )
-
     ctx = _make_ctx()
     fake_client = FakeClient()
     ctx.request_context.lifespan_context.client = fake_client
+    monkeypatch.setattr(
+        server,
+        "lsp_client_for_file",
+        lambda _ctx, _path: _fake_lsp_file(fake_client, "GoalSample.lean"),
+    )
 
     result = server.goal(ctx, file_path="/abs/GoalSample.lean", line=4, column=3)
 


### PR DESCRIPTION
Concurrent file-backed tools can race on the shared per-project `LeanLSPClient` document state, so this serializes each same-project LSP operation from file open through completion while still allowing separate projects to use separate clients.

This is intentionally conservative; broader parallel read support should be considered separately with explicit read/write leases and pinned open files.
