### PR TITLE
Fix Windows Lean source loading and LSP paths

### DIFF
--- a/src/lean_lsp_mcp/client_utils.py
+++ b/src/lean_lsp_mcp/client_utils.py
@@ -9,6 +9,7 @@ from lean_lsp_mcp.file_utils import (
     LeanPathPolicy,
     build_lean_path_policy,
     require_lean_project_path,
+    read_lean_source_utf8,
     resolve_input_path,
     valid_lean_project_path,
 )
@@ -354,6 +355,12 @@ async def setup_client_for_file(ctx: Context, file_path: str) -> str | None:
 
 
 async def open_synced(ctx: Context, rel_path: str, wait: bool = False):
-    """Open the file and sync it with the current on-disk content."""
+    """Open a Lean source file using UTF-8 instead of the OS default encoding."""
     client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
-    return await client.reload_from_disk(rel_path, wait=wait)
+    project_path = getattr(client, "project_path", None)
+    open_document = getattr(client, "open", None)
+    if project_path is None or open_document is None:
+        # Compatibility with minimal test doubles; AsyncLeanLSPClient has both APIs.
+        return await client.reload_from_disk(rel_path, wait=wait)
+    content = read_lean_source_utf8(Path(project_path) / rel_path)
+    return await open_document(rel_path, text=content, wait=wait)

--- a/src/lean_lsp_mcp/file_utils.py
+++ b/src/lean_lsp_mcp/file_utils.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from dataclasses import dataclass
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Optional
 
 
 _LAKEFILE_NAMES = ("lakefile.lean", "lakefile.toml")
 _STDLIB_DISPLAY_ROOT = ".lean-stdlib"
+_WINDOWS_DRIVE_URI_PATH = re.compile(r"^/+[A-Za-z]:[\\/]")
 
 
 @dataclass(frozen=True)
@@ -159,6 +161,15 @@ def resolve_input_path(
     if project_root is not None:
         return (project_root / path_obj).resolve(strict=require_exists)
     return path_obj.resolve(strict=require_exists)
+
+
+def lsp_location_path(location_path: str | Path) -> Path:
+    """Convert a path returned by an LSP location into a local path."""
+    value = str(location_path)
+    if os.name == "nt" and _WINDOWS_DRIVE_URI_PATH.match(value):
+        # leanclient exposes file URIs with leading slashes before the drive.
+        return Path(PureWindowsPath(value.lstrip("/")))
+    return Path(value)
 
 
 def get_relative_file_path(lean_project_path: Path, file_path: str) -> Optional[str]:

--- a/src/lean_lsp_mcp/file_utils.py
+++ b/src/lean_lsp_mcp/file_utils.py
@@ -186,6 +186,17 @@ def get_relative_file_path(lean_project_path: Path, file_path: str) -> Optional[
     return None
 
 
+def read_lean_source_utf8(abs_path: str | Path) -> str:
+    """Read Lean source strictly as UTF-8, independent of the OS code page."""
+    path_obj = Path(abs_path)
+    try:
+        return path_obj.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(
+            f"Could not decode Lean source {path_obj} using UTF-8: {exc}"
+        ) from exc
+
+
 def get_file_contents(abs_path: str | Path) -> str:
     path_obj = Path(abs_path)
     for enc in ("utf-8", "latin-1"):

--- a/src/lean_lsp_mcp/tools/analysis.py
+++ b/src/lean_lsp_mcp/tools/analysis.py
@@ -124,6 +124,7 @@ async def verify_theorem(
     from lean_lsp_mcp.verify import (
         check_axiom_errors,
         parse_axioms,
+        read_lean_source_utf8,
         scan_warnings,
     )
 
@@ -138,8 +139,10 @@ async def verify_theorem(
     except (FileNotFoundError, ValueError) as exc:
         raise server.LeanToolError(str(exc)) from exc
 
-    doc = await open_synced(ctx, rel_path)
-    original_content = doc.text
+    try:
+        original_content = read_lean_source_utf8(abs_path)
+    except ValueError as exc:
+        raise server.LeanToolError(str(exc)) from exc
 
     # Run the axiom check on a scratch copy; the real document is untouched.
     text = original_content.rstrip("\n") + f"\n\n#print axioms _root_.{theorem_name}\n"

--- a/src/lean_lsp_mcp/tools/analysis.py
+++ b/src/lean_lsp_mcp/tools/analysis.py
@@ -14,6 +14,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from lean_lsp_mcp import server
+from lean_lsp_mcp.file_utils import read_lean_source_utf8
 from lean_lsp_mcp.client_utils import (
     get_path_policy,
     get_scratch_pool,
@@ -124,7 +125,6 @@ async def verify_theorem(
     from lean_lsp_mcp.verify import (
         check_axiom_errors,
         parse_axioms,
-        read_lean_source_utf8,
         scan_warnings,
     )
 

--- a/src/lean_lsp_mcp/tools/navigation.py
+++ b/src/lean_lsp_mcp/tools/navigation.py
@@ -14,6 +14,7 @@ from pydantic import Field
 
 from lean_lsp_mcp import server
 from lean_lsp_mcp.client_utils import get_path_policy, open_synced
+from lean_lsp_mcp.file_utils import read_lean_source_utf8
 from lean_lsp_mcp.models import (
     CompletionItem,
     CompletionsResult,
@@ -212,7 +213,10 @@ async def declaration_file(
         server._raise_invalid_path(file_path)
 
     client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
-    await open_synced(ctx, rel_path)
+    try:
+        await open_synced(ctx, rel_path)
+    except ValueError as exc:
+        raise server.LeanToolError(str(exc)) from exc
     orig_file_content = client.content(rel_path)
 
     # Find the first occurence of the symbol (line and column) in the file
@@ -246,7 +250,10 @@ async def declaration_file(
             f"Could not open declaration file `{abs_path}` for `{symbol}`."
         )
 
-    file_content = server.get_file_contents(abs_path)
+    try:
+        file_content = read_lean_source_utf8(abs_path)
+    except ValueError as exc:
+        raise server.LeanToolError(str(exc)) from exc
     file_lines = file_content.splitlines()
     total_lines = len(file_lines)
 

--- a/src/lean_lsp_mcp/tools/navigation.py
+++ b/src/lean_lsp_mcp/tools/navigation.py
@@ -14,7 +14,7 @@ from pydantic import Field
 
 from lean_lsp_mcp import server
 from lean_lsp_mcp.client_utils import get_path_policy, open_synced
-from lean_lsp_mcp.file_utils import read_lean_source_utf8
+from lean_lsp_mcp.file_utils import lsp_location_path, read_lean_source_utf8
 from lean_lsp_mcp.models import (
     CompletionItem,
     CompletionsResult,
@@ -237,10 +237,11 @@ async def declaration_file(
 
     try:
         policy = get_path_policy(ctx)
+        location_path = lsp_location_path(local_path)
         abs_path = policy.validate_path(
-            Path(local_path)
-            if Path(local_path).is_absolute()
-            else Path(client.project_path) / local_path
+            location_path
+            if location_path.is_absolute()
+            else Path(client.project_path) / location_path
         )
     except ValueError as exc:
         raise server.LeanToolError(str(exc)) from exc
@@ -332,10 +333,11 @@ async def references(
         r = ref.get("range", {})
         display = ref.get("path", "")
         if display:
+            location_path = lsp_location_path(display)
             candidate = (
-                Path(display)
-                if Path(display).is_absolute()
-                else Path(client.project_path) / display
+                location_path
+                if location_path.is_absolute()
+                else Path(client.project_path) / location_path
             )
             try:
                 display = policy.display_path(candidate)

--- a/src/lean_lsp_mcp/verify.py
+++ b/src/lean_lsp_mcp/verify.py
@@ -28,20 +28,6 @@ _WARNING_PATTERNS: list[str] = [
 _COMBINED_PATTERN = "|".join(f"(?:{p})" for p in _WARNING_PATTERNS)
 
 
-def read_lean_source_utf8(file_path: Path) -> str:
-    """Read Lean source with its required UTF-8 encoding.
-
-    Lean files are UTF-8. Do not fall back to the platform default encoding:
-    on Windows that can be a legacy code page such as GBK.
-    """
-    try:
-        return file_path.read_text(encoding="utf-8")
-    except UnicodeDecodeError as exc:
-        raise ValueError(
-            f"Could not decode Lean source {file_path} using UTF-8: {exc}"
-        ) from exc
-
-
 def parse_axioms(diagnostics: list[dict]) -> list[str]:
     """Extract axiom names from #print axioms info diagnostics."""
     axioms: list[str] = []

--- a/src/lean_lsp_mcp/verify.py
+++ b/src/lean_lsp_mcp/verify.py
@@ -28,6 +28,20 @@ _WARNING_PATTERNS: list[str] = [
 _COMBINED_PATTERN = "|".join(f"(?:{p})" for p in _WARNING_PATTERNS)
 
 
+def read_lean_source_utf8(file_path: Path) -> str:
+    """Read Lean source with its required UTF-8 encoding.
+
+    Lean files are UTF-8. Do not fall back to the platform default encoding:
+    on Windows that can be a legacy code page such as GBK.
+    """
+    try:
+        return file_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(
+            f"Could not decode Lean source {file_path} using UTF-8: {exc}"
+        ) from exc
+
+
 def parse_axioms(diagnostics: list[dict]) -> list[str]:
     """Extract axiom names from #print axioms info diagnostics."""
     axioms: list[str] = []

--- a/tests/helpers/test_project.py
+++ b/tests/helpers/test_project.py
@@ -59,9 +59,9 @@ def ensure_test_project(repo_root: Path) -> Path:
 
 
 def _write_if_changed(path: Path, content: str) -> None:
-    if path.exists() and path.read_text() == content:
+    if path.exists() and path.read_text(encoding="utf-8") == content:
         return
-    path.write_text(content)
+    path.write_text(content, encoding="utf-8")
 
 
 def _should_refresh(project_root: Path) -> bool:

--- a/tests/unit/test_client_utils.py
+++ b/tests/unit/test_client_utils.py
@@ -401,3 +401,31 @@ def test_resolve_file_path_uses_project_root_for_relative(tmp_path: Path) -> Non
     ctx = _Context(_LifespanContext(project, None))
     resolved = resolve_file_path(ctx, "src/Example.lean")
     assert resolved == target.resolve()
+
+
+@pytest.mark.asyncio
+async def test_open_synced_reads_utf8_without_reload_from_disk(tmp_path: Path) -> None:
+    project = _make_project(tmp_path / "proj")
+    source = "-- Unicode: \u2212 \u2080 \u03b1\ntheorem clean : True := trivial\n"
+    (project / "Source.lean").write_text(source, encoding="utf-8")
+
+    class _Client:
+        project_path = str(project)
+
+        def __init__(self) -> None:
+            self.open_calls: list[tuple[str, str, bool]] = []
+
+        async def open(self, path: str, text: str, wait: bool = False):
+            self.open_calls.append((path, text, wait))
+            return object()
+
+        async def reload_from_disk(self, *_args, **_kwargs):
+            raise AssertionError("open_synced must not use the locale-dependent reload")
+
+    client = _Client()
+    ctx = _Context(_LifespanContext(project, client))
+
+    for _ in range(3):
+        await client_utils.open_synced(ctx, "Source.lean", wait=True)
+
+    assert client.open_calls == [("Source.lean", source, True)] * 3

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -9,6 +9,7 @@ from lean_lsp_mcp.file_utils import (
     build_lean_path_policy,
     get_file_contents,
     get_relative_file_path,
+    read_lean_source_utf8,
     require_lean_project_path,
     resolve_input_path,
 )
@@ -107,3 +108,16 @@ def test_get_file_contents_fallback_encoding(tmp_path: Path) -> None:
     latin1_file.write_text("caf\xe9", encoding="latin-1")
 
     assert get_file_contents(latin1_file) == "caf\xe9"
+
+
+def test_read_lean_source_utf8_is_strict_and_reports_encoding(tmp_path: Path) -> None:
+    source = "-- Unicode: \u2212 \u2080 \u03b1\ntheorem clean : True := trivial\n"
+    valid_file = tmp_path / "valid.lean"
+    valid_file.write_text(source, encoding="utf-8")
+    for _ in range(3):
+        assert read_lean_source_utf8(valid_file) == source
+
+    invalid_file = tmp_path / "invalid.lean"
+    invalid_file.write_bytes(b"-- invalid: \xff\n")
+    with pytest.raises(ValueError, match=r"using UTF-8"):
+        read_lean_source_utf8(invalid_file)

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -9,6 +9,7 @@ from lean_lsp_mcp.file_utils import (
     build_lean_path_policy,
     get_file_contents,
     get_relative_file_path,
+    lsp_location_path,
     read_lean_source_utf8,
     require_lean_project_path,
     resolve_input_path,
@@ -121,3 +122,19 @@ def test_read_lean_source_utf8_is_strict_and_reports_encoding(tmp_path: Path) ->
     invalid_file.write_bytes(b"-- invalid: \xff\n")
     with pytest.raises(ValueError, match=r"using UTF-8"):
         read_lean_source_utf8(invalid_file)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-specific LSP URI path")
+@pytest.mark.parametrize(
+    "location",
+    [
+        "/C:/Users/11388/reserach/HighDimProb/Main.lean",
+        "///C:/Users/11388/reserach/HighDimProb/Main.lean",
+    ],
+)
+def test_lsp_location_path_restores_windows_drive(location: str) -> None:
+    path = lsp_location_path(location)
+
+    assert path.is_absolute()
+    assert path.drive == "C:"
+    assert path == Path(r"C:\Users\11388\reserach\HighDimProb\Main.lean")

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -689,6 +689,87 @@ async def test_declaration_file_sanitizes_dependency_path(
 
 
 @pytest.mark.asyncio
+async def test_declaration_file_reads_utf8_source_repeatedly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    source_file = project / "Unicode.lean"
+    source = (
+        "-- Unicode: \u2212 \u2080 \u03b1\ntheorem unicodeTarget : True := by trivial\n"
+    )
+    source_file.write_text(source, encoding="utf-8")
+
+    class FakeClient:
+        project_path = str(project)
+
+        def __init__(self) -> None:
+            self.open_calls: list[tuple[str, str, bool]] = []
+
+        async def open(self, path: str, text: str, wait: bool = False):
+            self.open_calls.append((path, text, wait))
+            return types.SimpleNamespace(text=text)
+
+        def content(self, _path: str) -> str:
+            return source
+
+        async def goto(self, kind: str, _path: str, _line: int, _column: int):
+            assert kind == "declaration"
+            return [
+                {
+                    "path": str(source_file),
+                    "range": {
+                        "start": {"line": 1, "character": 0},
+                        "end": {"line": 1, "character": 28},
+                    },
+                }
+            ]
+
+    client = FakeClient()
+    ctx = _make_ctx(lean_project_path=project)
+    ctx.request_context.lifespan_context.client = client
+    monkeypatch.setattr(server, "setup_client_for_file", _async_setup("Unicode.lean"))
+
+    for _ in range(3):
+        result = await server.declaration_file(
+            ctx=ctx,
+            file_path=str(source_file),
+            symbol="unicodeTarget",
+            context_lines=1,
+        )
+        assert "unicodeTarget" in result.content
+
+    assert client.open_calls == [("Unicode.lean", source, False)] * 3
+
+
+@pytest.mark.asyncio
+async def test_declaration_file_reports_utf8_decode_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    source_file = project / "Invalid.lean"
+    source_file.write_bytes(b"-- invalid: \xff\n")
+
+    class FakeClient:
+        project_path = str(project)
+
+        async def open(self, *_args, **_kwargs):
+            raise AssertionError(
+                "invalid UTF-8 must be rejected before opening the LSP doc"
+            )
+
+    ctx = _make_ctx(lean_project_path=project)
+    ctx.request_context.lifespan_context.client = FakeClient()
+    monkeypatch.setattr(server, "setup_client_for_file", _async_setup("Invalid.lean"))
+
+    with pytest.raises(server.LeanToolError, match=r"using UTF-8"):
+        await server.declaration_file(
+            ctx=ctx,
+            file_path=str(source_file),
+            symbol="missing",
+        )
+
+
+@pytest.mark.asyncio
 async def test_references_sanitize_paths_and_skip_outside_policy(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import json
+import os
 import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -739,6 +740,56 @@ async def test_declaration_file_reads_utf8_source_repeatedly(
         assert "unicodeTarget" in result.content
 
     assert client.open_calls == [("Unicode.lean", source, False)] * 3
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-specific LSP URI path")
+@pytest.mark.asyncio
+async def test_declaration_file_normalizes_windows_lsp_uri_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    source_file = project / "WindowsLocation.lean"
+    source = "theorem windowsLocationTarget : True := by trivial\n"
+    source_file.write_text(source, encoding="utf-8")
+
+    class FakeClient:
+        project_path = str(project)
+
+        async def open(self, _path: str, text: str, wait: bool = False):
+            assert text == source
+            assert wait is False
+            return types.SimpleNamespace(text=text)
+
+        def content(self, _path: str) -> str:
+            return source
+
+        async def goto(self, kind: str, _path: str, _line: int, _column: int):
+            assert kind == "declaration"
+            return [
+                {
+                    "path": "///" + source_file.as_posix(),
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": len(source.rstrip())},
+                    },
+                }
+            ]
+
+    ctx = _make_ctx(lean_project_path=project)
+    ctx.request_context.lifespan_context.client = FakeClient()
+    monkeypatch.setattr(
+        server, "setup_client_for_file", _async_setup("WindowsLocation.lean")
+    )
+
+    result = await server.declaration_file(
+        ctx=ctx,
+        file_path=str(source_file),
+        symbol="windowsLocationTarget",
+        context_lines=1,
+    )
+
+    assert result.file_path == "WindowsLocation.lean"
+    assert "windowsLocationTarget" in result.content
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
 from lean_lsp_mcp.verify import (
     check_axiom_errors,
     parse_axioms,
+    read_lean_source_utf8,
     scan_warnings,
 )
 
@@ -101,3 +104,100 @@ class TestScanWarnings:
 
     def test_nonexistent(self, tmp_path: Path):
         assert scan_warnings(tmp_path / "nope.lean") == []
+
+
+class TestReadLeanSourceUtf8:
+    def test_reads_utf8_regardless_of_platform_default(self, tmp_path: Path):
+        source = "-- Unicode: \u2212 \u2080 \u03b1\ntheorem clean : True := trivial\n"
+        file_path = tmp_path / "unicode.lean"
+        file_path.write_text(source, encoding="utf-8")
+
+        assert read_lean_source_utf8(file_path) == source
+
+    def test_reports_utf8_when_decoding_fails(self, tmp_path: Path):
+        file_path = tmp_path / "invalid.lean"
+        file_path.write_bytes(b"-- invalid: \xff\n")
+
+        with pytest.raises(ValueError, match=r"using UTF-8"):
+            read_lean_source_utf8(file_path)
+
+
+@pytest.mark.asyncio
+async def test_verify_reads_utf8_without_opening_document(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    from lean_lsp_mcp import server
+    from lean_lsp_mcp.tools import analysis
+
+    file_path = tmp_path / "unicode.lean"
+    file_path.write_text(
+        "-- Unicode: \u2212 \u2080 \u03b1\ntheorem clean : True := trivial\n",
+        encoding="utf-8",
+    )
+
+    class Policy:
+        def validate_path(self, path: Path) -> Path:
+            return path
+
+    class Pool:
+        async def run_text(self, text: str):
+            return SimpleNamespace(
+                diagnostics=SimpleNamespace(
+                    items=[
+                        {
+                            "severity": 3,
+                            "message": "'clean' does not depend on any axioms",
+                            "range": {"start": {"line": 999}},
+                        }
+                    ]
+                )
+            )
+
+    monkeypatch.setattr(server, "_validate_theorem_name", lambda name: name)
+    monkeypatch.setattr(
+        server, "setup_client_for_file", AsyncMock(return_value="unicode.lean")
+    )
+    monkeypatch.setattr(server, "resolve_file_path", lambda _ctx, _path: file_path)
+    monkeypatch.setattr(server, "_RG_AVAILABLE", False)
+    monkeypatch.setattr(analysis, "get_path_policy", lambda _ctx: Policy())
+    monkeypatch.setattr(analysis, "get_scratch_pool", lambda _ctx: Pool())
+    monkeypatch.setattr(
+        analysis,
+        "open_synced",
+        AsyncMock(
+            side_effect=AssertionError("lean_verify must not read via open_synced")
+        ),
+    )
+
+    result = await analysis.verify_theorem(
+        object(), str(file_path), "Namespace.clean", scan_source=False
+    )
+
+    assert result.axioms == []
+
+
+@pytest.mark.asyncio
+async def test_verify_reports_utf8_decode_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    from lean_lsp_mcp import server
+    from lean_lsp_mcp.tools import analysis
+
+    file_path = tmp_path / "invalid.lean"
+    file_path.write_bytes(b"-- invalid: \xff\n")
+
+    class Policy:
+        def validate_path(self, path: Path) -> Path:
+            return path
+
+    monkeypatch.setattr(server, "_validate_theorem_name", lambda name: name)
+    monkeypatch.setattr(
+        server, "setup_client_for_file", AsyncMock(return_value="invalid.lean")
+    )
+    monkeypatch.setattr(server, "resolve_file_path", lambda _ctx, _path: file_path)
+    monkeypatch.setattr(analysis, "get_path_policy", lambda _ctx: Policy())
+
+    with pytest.raises(server.LeanToolError, match=r"using UTF-8"):
+        await analysis.verify_theorem(
+            object(), str(file_path), "Namespace.invalid", scan_source=False
+        )

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -9,10 +9,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from lean_lsp_mcp.file_utils import read_lean_source_utf8
 from lean_lsp_mcp.verify import (
     check_axiom_errors,
     parse_axioms,
-    read_lean_source_utf8,
     scan_warnings,
 )
 


### PR DESCRIPTION
## Summary
- Read Lean source files as UTF-8 instead of the Windows ANSI code page.
- Normalize Windows drive-qualified paths returned from LSP locations, including leanclient's ///C:/... form derived from ile://///C:/... URIs.
- Apply the location normalization to declaration and reference navigation.

## Validation
- Added Windows regression coverage for single- and triple-slash drive URI paths and declaration lookup.
- Targeted UTF-8 and Windows-path tests: 5 passed.
- Fresh MCP processes successfully resolved C:/..., C:\\..., and ..\\HighDimProb\\... inputs for lean_declaration_file.
- Ruff and git diff --check passed.

The existing Windows separator expectation in 	est_get_relative_file_path_handles_absolute_and_relative remains unrelated to this change.

Closes #211