### PR TITLE
Close idle stdio Lean clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ This MCP server works out-of-the-box without any configuration. However, a few o
 - `LEAN_LOG_LEVEL`: Log level for the server. Options are "INFO", "WARNING", "ERROR", "NONE". Defaults to "INFO".
 - `LEAN_LOG_FILE_CONFIG`: Config file path for logging, with priority over `LEAN_LOG_LEVEL`. If not set, logs are printed to stdout.
 - `LEAN_PROJECT_PATH`: Path to your Lean project root. A valid Lean project root must contain `lean-toolchain` and either `lakefile.lean` or `lakefile.toml`. Relative `file_path` arguments resolve against this root. This variable is required for `streamable-http` and `sse`.
+- `LEAN_LSP_MAX_OPEN_FILES`: Maximum number of Lean files retained by one language-server client. Defaults to `4`; set it to `1` when memory is constrained.
+- `LEAN_LSP_IDLE_TIMEOUT_SECONDS`: For `stdio` transport, close an idle Lean language-server tree after this many seconds while leaving the MCP wrapper reusable. Defaults to `600`; set a non-positive value to disable idle cleanup. The next LSP-backed tool call recreates the client. Multi-session `streamable-http` and `sse` transports are not idle-evicted.
 - `LEAN_MCP_DISABLED_TOOLS`: Comma-separated list of tool names to remove from MCP tool listing.
 - `LEAN_MCP_INSTRUCTIONS`: Replacement server instructions string.
 - `LEAN_MCP_TOOL_DESCRIPTIONS`: JSON object mapping tool names to replacement descriptions.

--- a/src/lean_lsp_mcp/client_utils.py
+++ b/src/lean_lsp_mcp/client_utils.py
@@ -1,3 +1,4 @@
+import time
 from pathlib import Path
 from threading import Lock
 
@@ -177,7 +178,8 @@ def replace_shared_client(
     return previous
 
 
-def close_shared_client(project_path: Path | str | None = None) -> None:
+def take_shared_clients(project_path: Path | str | None = None) -> list[LeanLSPClient]:
+    """Remove and return cached clients without closing them."""
     clients: list[LeanLSPClient] = []
 
     with CLIENT_LOCK:
@@ -192,12 +194,18 @@ def close_shared_client(project_path: Path | str | None = None) -> None:
                 clients.append(client)
             _builds_in_progress.discard(project_key)
 
+    return clients
+
+
+def close_shared_client(project_path: Path | str | None = None) -> None:
+    clients = take_shared_clients(project_path)
     for client in clients:
         _close_client(client, "Shared Lean client close failed during shutdown")
 
 
 def startup_client(ctx: Context):
     """Initialize the Lean LSP client if not already set up."""
+    ctx.request_context.lifespan_context.last_lsp_activity = time.monotonic()
     with CLIENT_LOCK:
         configured_root = ctx.request_context.lifespan_context.lean_project_path
         if configured_root is None:

--- a/src/lean_lsp_mcp/config.py
+++ b/src/lean_lsp_mcp/config.py
@@ -9,6 +9,7 @@ cached at import time.
 from __future__ import annotations
 
 import logging
+import math
 import os
 
 logger = logging.getLogger(__name__)
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 # --- Environment variable names (single source of truth) ---
 ACTIVE_TRANSPORT_ENV = "LEAN_LSP_MCP_ACTIVE_TRANSPORT"
 MAX_OPEN_FILES_ENV = "LEAN_LSP_MAX_OPEN_FILES"
+IDLE_TIMEOUT_SECONDS_ENV = "LEAN_LSP_IDLE_TIMEOUT_SECONDS"
 TEST_MODE_ENV = "LEAN_LSP_TEST_MODE"
 PROJECT_PATH_ENV = "LEAN_PROJECT_PATH"
 AUTH_TOKEN_ENV = "LEAN_LSP_MCP_TOKEN"
@@ -72,6 +74,29 @@ def max_open_files() -> int:
     if value < 1:
         logger.warning("Invalid %s=%s, defaulting to 4.", MAX_OPEN_FILES_ENV, raw_value)
         return 4
+    return value
+
+
+def idle_timeout_seconds() -> float | None:
+    raw_value = os.environ.get(IDLE_TIMEOUT_SECONDS_ENV, "600").strip()
+    try:
+        value = float(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%s, defaulting to 600.",
+            IDLE_TIMEOUT_SECONDS_ENV,
+            raw_value,
+        )
+        return 600.0
+    if not math.isfinite(value):
+        logger.warning(
+            "Invalid %s=%s, defaulting to 600.",
+            IDLE_TIMEOUT_SECONDS_ENV,
+            raw_value,
+        )
+        return 600.0
+    if value <= 0:
+        return None
     return value
 
 

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -32,6 +32,7 @@ from lean_lsp_mcp.client_utils import (
     resolve_file_path,
     set_build_in_progress,
     setup_client_for_file,
+    take_shared_clients,
 )
 from lean_lsp_mcp.file_utils import (
     build_lean_path_policy,
@@ -309,12 +310,44 @@ class AppContext:
     repl: Repl | None = None
     repl_enabled: bool = False
     build_coordinator: BuildCoordinator | None = None
+    last_lsp_activity: float = 0.0
+
+
+def _close_stdio_client(context: AppContext, failure_message: str) -> None:
+    """Close this stdio session's project client and remove its cache entry."""
+    client = context.client
+    context.client = None
+    clients_to_close: list[LeanLSPClient] = []
+    for candidate in (client, *take_shared_clients()):
+        if candidate is None or candidate in clients_to_close:
+            continue
+        clients_to_close.append(candidate)
+
+    for client_to_close in clients_to_close:
+        try:
+            client_to_close.close()
+        except Exception:
+            logger.exception(failure_message)
+
+
+async def _close_idle_stdio_client(context: AppContext, timeout_seconds: float) -> None:
+    """Release an idle stdio Lean tree while keeping the MCP wrapper reusable."""
+    poll_seconds = min(timeout_seconds, 30.0)
+    while True:
+        await asyncio.sleep(poll_seconds)
+        if context.client is None:
+            continue
+        if time.monotonic() - context.last_lsp_activity < timeout_seconds:
+            continue
+        logger.info("Stdio Lean client idle for %.1fs; closing it", timeout_seconds)
+        _close_stdio_client(context, "Lean client close failed during idle teardown")
 
 
 @asynccontextmanager
 async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     repl: Repl | None = None
     context: AppContext | None = None
+    idle_cleanup_task: asyncio.Task[None] | None = None
 
     try:
         active_transport = _active_transport()
@@ -376,15 +409,34 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
             repl=repl,
             repl_enabled=repl_available,
             build_coordinator=build_coordinator,
+            last_lsp_activity=time.monotonic(),
         )
+        if active_transport == "stdio" and (
+            idle_timeout_seconds := config.idle_timeout_seconds()
+        ) is not None:
+            idle_cleanup_task = asyncio.create_task(
+                _close_idle_stdio_client(context, idle_timeout_seconds)
+            )
         yield context
     finally:
         logger.info("Session ending — cleaning up per-session resources")
 
-        # NOTE: Do NOT close context.client here.  The LSP client is a shared
-        # singleton managed by client_utils.  Closing it would kill ``lake
-        # serve`` for all other sessions.  The shared client is cleaned up via
-        # close_shared_client() at process exit (see __init__.py).
+        if idle_cleanup_task is not None:
+            idle_cleanup_task.cancel()
+            try:
+                await idle_cleanup_task
+            except asyncio.CancelledError:
+                pass
+
+        if context and context.active_transport == "stdio":
+            # A stdio MCP process serves exactly one client session. Keeping
+            # its project-scoped client alive after that session ends retains
+            # the whole lake-serve tree until the wrapper process exits.
+            _close_stdio_client(context, "Lean client close failed during stdio teardown")
+
+        # Streamable HTTP can run multiple sessions in one MCP process. Its
+        # project-scoped client remains shared until process exit so one
+        # disconnect does not kill lake serve for the other sessions.
 
         repl_to_close = context.repl if context and context.repl is not None else repl
         if repl_to_close:

--- a/src/lean_lsp_mcp/tools/analysis.py
+++ b/src/lean_lsp_mcp/tools/analysis.py
@@ -96,19 +96,14 @@ def run_code(
     except Exception as e:
         raise server.LeanToolError(f"Error writing code snippet: {e}")
 
+    startup_client(ctx)
     client: LeanLSPClient | None = lifespan_context.client
+    if client is None:
+        raise server.LeanToolError("Failed to initialize Lean client for run_code.")
     raw_diagnostics: Iterable[Dict] = []
     opened_file = False
 
     try:
-        if client is None:
-            startup_client(ctx)
-            client = lifespan_context.client
-            if client is None:
-                raise server.LeanToolError(
-                    "Failed to initialize Lean client for run_code."
-                )
-
         client.open_file(rel_path)
         opened_file = True
         raw_diagnostics = client.get_diagnostics(rel_path, inactivity_timeout=15.0)

--- a/tests/unit/test_client_utils.py
+++ b/tests/unit/test_client_utils.py
@@ -122,14 +122,18 @@ def test_startup_client_reuses_existing(
 ) -> None:
     project = _make_project(tmp_path / "proj")
     ctx = _Context(_LifespanContext(project, None))
+    ctx.request_context.lifespan_context.last_lsp_activity = 0.0
 
     startup_client(ctx)
     first = ctx.request_context.lifespan_context.client
     assert isinstance(first, _MockLeanClient)
     assert not first.closed
+    assert ctx.request_context.lifespan_context.last_lsp_activity > 0
 
+    ctx.request_context.lifespan_context.last_lsp_activity = 0.0
     startup_client(ctx)
     assert ctx.request_context.lifespan_context.client is first
+    assert ctx.request_context.lifespan_context.last_lsp_activity > 0
     assert len(patched_clients) == 1
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,6 +25,21 @@ def test_max_open_files(monkeypatch: pytest.MonkeyPatch):
     assert config.max_open_files() == 4
 
 
+def test_idle_timeout_seconds(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(config.IDLE_TIMEOUT_SECONDS_ENV, raising=False)
+    assert config.idle_timeout_seconds() == 600.0
+    monkeypatch.setenv(config.IDLE_TIMEOUT_SECONDS_ENV, "30")
+    assert config.idle_timeout_seconds() == 30.0
+    monkeypatch.setenv(config.IDLE_TIMEOUT_SECONDS_ENV, "0")
+    assert config.idle_timeout_seconds() is None
+    monkeypatch.setenv(config.IDLE_TIMEOUT_SECONDS_ENV, "not-a-number")
+    assert config.idle_timeout_seconds() == 600.0
+    monkeypatch.setenv(config.IDLE_TIMEOUT_SECONDS_ENV, "NaN")
+    assert config.idle_timeout_seconds() == 600.0
+    monkeypatch.setenv(config.IDLE_TIMEOUT_SECONDS_ENV, "inf")
+    assert config.idle_timeout_seconds() == 600.0
+
+
 def test_build_concurrency(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv(config.BUILD_CONCURRENCY_ENV, raising=False)
     assert config.build_concurrency() == "allow"

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -45,6 +45,7 @@ def _clear_optional_runtime_flags(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LEAN_LSP_MCP_TOKEN", raising=False)
     monkeypatch.delenv("LEAN_LOOGLE_LOCAL", raising=False)
     monkeypatch.delenv("LEAN_REPL", raising=False)
+    monkeypatch.delenv("LEAN_LSP_IDLE_TIMEOUT_SECONDS", raising=False)
     monkeypatch.delenv("LEAN_LSP_MCP_ACTIVE_TRANSPORT", raising=False)
     client_utils.close_shared_client()
 
@@ -126,11 +127,41 @@ async def test_app_lifespan_requires_project_path_for_remote_transport(
 
 
 @pytest.mark.asyncio
-async def test_app_lifespan_does_not_close_shared_client(
+async def test_app_lifespan_closes_shared_client_for_stdio(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    """The LSP client is a shared singleton — app_lifespan must NOT close it."""
+    """A one-session stdio wrapper must release its Lean server tree."""
     monkeypatch.delenv("LEAN_LOG_LEVEL", raising=False)
+    project_dir = _make_project(tmp_path / "proj")
+    old_project_dir = _make_project(tmp_path / "old-proj")
+    monkeypatch.setenv("LEAN_PROJECT_PATH", str(project_dir))
+
+    dummy_client = DummyClient()
+    old_project_client = DummyClient()
+    client_utils._shared_clients[project_dir.resolve()] = dummy_client
+    client_utils._shared_clients[old_project_dir.resolve()] = old_project_client
+
+    try:
+        async with server.app_lifespan(object()) as context:
+            context.client = dummy_client
+
+        assert dummy_client.closed_calls == 1
+        assert old_project_client.closed_calls == 1
+        assert client_utils._shared_clients == {}
+    finally:
+        client_utils._shared_clients.clear()
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_keeps_shared_client_for_streamable_http(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Remote transports can have other sessions sharing one Lean client."""
+    project_dir = _make_project(tmp_path / "proj")
+    monkeypatch.setenv("LEAN_PROJECT_PATH", str(project_dir))
+    monkeypatch.setenv("LEAN_LSP_MCP_ACTIVE_TRANSPORT", "streamable-http")
 
     dummy_client = DummyClient()
 
@@ -138,6 +169,32 @@ async def test_app_lifespan_does_not_close_shared_client(
         context.client = dummy_client
 
     assert dummy_client.closed_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_idle_stdio_client_closes_shared_client(tmp_path: Path) -> None:
+    project_dir = _make_project(tmp_path / "proj")
+    dummy_client = DummyClient()
+    context = server.AppContext(
+        lean_project_path=project_dir.resolve(),
+        client=dummy_client,
+        rate_limit={"test": []},
+        lean_search_available=True,
+        last_lsp_activity=0.0,
+    )
+    client_utils._shared_clients[project_dir.resolve()] = dummy_client
+    task = asyncio.create_task(server._close_idle_stdio_client(context, 0.01))
+
+    try:
+        await asyncio.sleep(0.03)
+        assert dummy_client.closed_calls == 1
+        assert context.client is None
+        assert client_utils._shared_clients == {}
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        client_utils._shared_clients.clear()
 
 
 def test_close_shared_client_closes_client() -> None:


### PR DESCRIPTION
## What changed

- Close cached Lean language-server clients when a stdio MCP session ends.
- Add a stdio-only idle reaper controlled by `LEAN_LSP_IDLE_TIMEOUT_SECONDS` (default: 600 seconds; non-positive disables it).
- Refresh LSP activity on client startup and `lean_run_code` reuse.
- Keep streamable HTTP and SSE clients shared across sessions.
- Document the memory controls and add focused lifecycle/config/client tests.

## Root cause

Each Codex task can retain its own stdio `lean-lsp-mcp` wrapper. The previous
lifespan teardown intentionally kept the shared Lean client alive until process
exit, so abandoned wrappers retained their `lake serve` / `lean --server` /
`lean --worker` trees indefinitely. Repeated tasks therefore accumulated large
idle Lean process trees.

## Impact

Stdio wrappers now release their heavy Lean subprocess tree at session teardown,
and idle wrappers release it after the configured timeout while remaining
reusable. The next LSP-backed call recreates the client. Multi-session remote
transports preserve their existing sharing semantics.

## Validation

- `uv run --extra dev pytest tests/unit/test_server.py tests/unit/test_config.py tests/unit/test_client_utils.py tests/unit/test_windows_encoding.py -q` (`78 passed`)
- `uv run --extra dev pytest tests/unit/test_main.py tests/test_transport_disconnect.py -q` (`7 passed`)
- `uv run --extra dev ruff check ...`
- `uv run --extra dev ty check src`
- `git diff --check`
