### PR TITLE
Migrate to MCP Python SDK v2 (2026-07-28 spec)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Oliver Dressler", email = "hey@oli.show" }]
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
-dependencies = ["leanclient>=0.13.0", "mcp[cli]==1.28.1", "orjson>=3.11.9", "certifi>=2026.7.22"]
+dependencies = ["leanclient>=0.13.0", "mcp[cli]==2.0.0", "orjson>=3.11.9", "certifi>=2026.7.22"]
 
 [project.urls]
 Repository = "https://github.com/oOo0oOo/lean-lsp-mcp"

--- a/src/lean_lsp_mcp/__init__.py
+++ b/src/lean_lsp_mcp/__init__.py
@@ -2,12 +2,11 @@ import argparse
 import os
 import sys
 from contextlib import suppress
-from importlib.metadata import version
 
 import anyio
 from lean_lsp_mcp import config
 from lean_lsp_mcp.client_utils import close_shared_client, infer_project_path
-from lean_lsp_mcp.server import apply_tool_configuration, mcp
+from lean_lsp_mcp.server import VERSION, apply_tool_configuration, mcp
 
 _TRANSPORT_CLOSE_HINTS = (
     "transport closed",
@@ -66,7 +65,7 @@ def main():
         "-v",
         "--version",
         action="version",
-        version=f"%(prog)s {version('lean-lsp-mcp')}",
+        version=f"%(prog)s {VERSION}",
     )
     parser.add_argument(
         "--transport",

--- a/src/lean_lsp_mcp/__init__.py
+++ b/src/lean_lsp_mcp/__init__.py
@@ -153,10 +153,11 @@ def main():
     os.environ[config.ACTIVE_TRANSPORT_ENV] = args.transport
 
     apply_tool_configuration(mcp)
-    mcp.settings.host = args.host
-    mcp.settings.port = args.port
     try:
-        mcp.run(transport=args.transport)
+        if args.transport == "stdio":
+            mcp.run(transport="stdio")
+        else:
+            mcp.run(transport=args.transport, host=args.host, port=args.port)
     except KeyboardInterrupt:
         return 130
     except Exception as exc:

--- a/src/lean_lsp_mcp/client_utils.py
+++ b/src/lean_lsp_mcp/client_utils.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import asyncio
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from leanclient.aio import AsyncLeanLSPClient, ScratchPool
-from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.utilities.logging import get_logger
 
 from lean_lsp_mcp.file_utils import (
@@ -13,6 +15,9 @@ from lean_lsp_mcp.file_utils import (
     valid_lean_project_path,
 )
 from lean_lsp_mcp import config
+
+if TYPE_CHECKING:
+    from lean_lsp_mcp.server import ToolContext
 
 
 logger = get_logger(__name__)
@@ -26,7 +31,7 @@ _builds_in_progress: set[Path] = set()
 _MAX_SHARED_CLIENTS = 8
 
 
-def _active_transport(ctx: Context | None = None) -> str:
+def _active_transport(ctx: ToolContext | None = None) -> str:
     if ctx is not None:
         lifespan = ctx.request_context.lifespan_context
         transport = getattr(lifespan, "active_transport", None)
@@ -35,7 +40,7 @@ def _active_transport(ctx: Context | None = None) -> str:
     return config.active_transport()
 
 
-def _project_switching_allowed(ctx: Context | None = None) -> bool:
+def _project_switching_allowed(ctx: ToolContext | None = None) -> bool:
     if ctx is not None:
         lifespan = ctx.request_context.lifespan_context
         explicit = getattr(lifespan, "project_switching_allowed", None)
@@ -48,7 +53,7 @@ def _max_opened_files() -> int:
     return config.max_open_files()
 
 
-def bind_lean_project_path(ctx: Context, project_path: Path | str) -> Path:
+def bind_lean_project_path(ctx: ToolContext, project_path: Path | str) -> Path:
     lifespan = ctx.request_context.lifespan_context
     resolved_project = require_lean_project_path(project_path)
     current_root: Path | None = getattr(lifespan, "lean_project_path", None)
@@ -77,7 +82,9 @@ def bind_lean_project_path(ctx: Context, project_path: Path | str) -> Path:
     return resolved_project
 
 
-def get_path_policy(ctx: Context, project_path: Path | None = None) -> LeanPathPolicy:
+def get_path_policy(
+    ctx: ToolContext, project_path: Path | None = None
+) -> LeanPathPolicy:
     lifespan = ctx.request_context.lifespan_context
     root = project_path or getattr(lifespan, "lean_project_path", None)
     if root is None:
@@ -144,7 +151,7 @@ async def _get_or_create_shared_client(
     return client
 
 
-def get_scratch_pool(ctx: Context) -> ScratchPool:
+def get_scratch_pool(ctx: ToolContext) -> ScratchPool:
     """Per-project pre-warmed virtual-document pool for snippet trials.
 
     Slots warm lazily with empty content; the first trial that imports
@@ -171,7 +178,7 @@ def get_scratch_pool(ctx: Context) -> ScratchPool:
     return pool
 
 
-def get_serial_scratch_pool(ctx: Context) -> ScratchPool:
+def get_serial_scratch_pool(ctx: ToolContext) -> ScratchPool:
     """Single-slot pool for scratch tools that issue one trial at a time.
 
     Keeping sequential work separate from the parallel trial pool prevents
@@ -197,7 +204,7 @@ def get_serial_scratch_pool(ctx: Context) -> ScratchPool:
     return pool
 
 
-def get_run_code_pool(ctx: Context) -> ScratchPool:
+def get_run_code_pool(ctx: ToolContext) -> ScratchPool:
     """Backward-compatible name for the sequential scratch pool."""
     return get_serial_scratch_pool(ctx)
 
@@ -254,7 +261,7 @@ def close_shared_client(project_path: Path | str | None = None) -> None:
             logger.exception("Shared Lean client terminate failed during shutdown")
 
 
-async def startup_client(ctx: Context) -> AsyncLeanLSPClient:
+async def startup_client(ctx: ToolContext) -> AsyncLeanLSPClient:
     """Ensure the shared async Lean client for the session's project is up."""
     async with CLIENT_LOCK:
         configured_root = ctx.request_context.lifespan_context.lean_project_path
@@ -266,8 +273,15 @@ async def startup_client(ctx: Context) -> AsyncLeanLSPClient:
         return client
 
 
+def get_client(ctx: ToolContext) -> AsyncLeanLSPClient:
+    client = ctx.request_context.lifespan_context.client
+    if client is None:
+        raise ValueError("Lean client is not running for this project.")
+    return client
+
+
 def resolve_file_path(
-    ctx: Context, file_path: str, *, require_exists: bool = True
+    ctx: ToolContext, file_path: str, *, require_exists: bool = True
 ) -> Path:
     """Resolve a file path with support for project-root-relative inputs."""
     lifespan = ctx.request_context.lifespan_context
@@ -299,12 +313,10 @@ def _cacheable_project_dirs(project_path: Path, cache_dirs: list[str]) -> list[s
     ]
 
 
-def infer_project_path(file_path: str, ctx: Context | None = None) -> Path | None:
+def infer_project_path(file_path: str, ctx: ToolContext | None = None) -> Path | None:
     """Infer and cache the Lean project path for a file WITHOUT starting the client."""
     if ctx:
         lifespan = ctx.request_context.lifespan_context
-        if not hasattr(lifespan, "project_cache"):
-            lifespan.project_cache = {}
 
     if ctx is not None:
         resolved_input = resolve_file_path(ctx, file_path, require_exists=False)
@@ -368,7 +380,7 @@ def infer_project_path(file_path: str, ctx: Context | None = None) -> Path | Non
     return None
 
 
-async def setup_client_for_file(ctx: Context, file_path: str) -> str | None:
+async def setup_client_for_file(ctx: ToolContext, file_path: str) -> str | None:
     """Ensure the LSP client matches the file's Lean project and return its relative path."""
     try:
         resolved_file = str(resolve_file_path(ctx, file_path))
@@ -390,7 +402,7 @@ async def setup_client_for_file(ctx: Context, file_path: str) -> str | None:
     return policy.client_relative_path(resolved_file)
 
 
-async def open_synced(ctx: Context, rel_path: str, wait: bool = False):
+async def open_synced(ctx: ToolContext, rel_path: str, wait: bool = False):
     """Open the file and sync it with the current on-disk content."""
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     return await client.reload_from_disk(rel_path, wait=wait)

--- a/src/lean_lsp_mcp/client_utils.py
+++ b/src/lean_lsp_mcp/client_utils.py
@@ -2,8 +2,8 @@ import asyncio
 from pathlib import Path
 
 from leanclient.aio import AsyncLeanLSPClient, ScratchPool
-from mcp.server.fastmcp import Context
-from mcp.server.fastmcp.utilities.logging import get_logger
+from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.utilities.logging import get_logger
 
 from lean_lsp_mcp.file_utils import (
     LeanPathPolicy,

--- a/src/lean_lsp_mcp/models.py
+++ b/src/lean_lsp_mcp/models.py
@@ -206,7 +206,7 @@ class DeclarationInfo(BaseModel):
 
 
 # Wrapper models for list-returning tools
-# FastMCP flattens bare lists into separate TextContent blocks, causing serialization issues.
+# MCPServer flattens bare lists into separate TextContent blocks, causing serialization issues.
 # Wrapping in a model ensures proper JSON serialization.
 
 

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -22,8 +22,8 @@ from leanclient.aio import (
     LeanClientError,
 )
 from mcp.server.auth.settings import AuthSettings
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.server.fastmcp.utilities.logging import configure_logging, get_logger
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.utilities.logging import configure_logging, get_logger
 
 from lean_lsp_mcp.client_utils import (
     _active_transport,
@@ -151,7 +151,7 @@ def _load_tool_description_overrides() -> dict[str, str]:
     return overrides
 
 
-def apply_tool_configuration(server: FastMCP) -> None:
+def apply_tool_configuration(server: MCPServer) -> None:
     """Apply optional runtime tool configuration from environment variables."""
     disabled = _parse_disabled_tools(config.disabled_tools_raw())
     for name in sorted(disabled):
@@ -164,7 +164,7 @@ def apply_tool_configuration(server: FastMCP) -> None:
 
     instructions_override = config.instructions_override()
     if instructions_override is not None:
-        server._mcp_server.instructions = instructions_override
+        server._lowlevel_server.instructions = instructions_override
         logger.info("Overrode server instructions via %s", _INSTRUCTIONS_ENV)
 
     description_overrides = _load_tool_description_overrides()
@@ -374,7 +374,7 @@ def _maybe_start_prewarm(lean_project_path: Path | None) -> None:
 
 
 @asynccontextmanager
-async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
+async def app_lifespan(server: MCPServer) -> AsyncIterator[AppContext]:
     repl: Repl | None = None
     context: AppContext | None = None
 
@@ -472,7 +472,7 @@ if auth_token:
     )
     mcp_kwargs["token_verifier"] = PreSharedTokenVerifier(auth_token)
 
-mcp = FastMCP(**mcp_kwargs)
+mcp = MCPServer(**mcp_kwargs)
 
 # Symbols imported here but used only by the tool subpackage (via `server.X`)
 # or by tests through monkeypatching. Listing them in __all__ marks them as

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import importlib
+import importlib.metadata
 import json
 import logging.config
 import os
@@ -462,9 +463,12 @@ async def app_lifespan(server: MCPServer) -> AsyncIterator[AppContext]:
                 logger.exception("REPL close failed during app_lifespan teardown")
 
 
+VERSION = importlib.metadata.version("lean-lsp-mcp")
+
 mcp_kwargs: dict[str, Any] = dict(
     name="Lean LSP",
     instructions=INSTRUCTIONS,
+    version=VERSION,
     dependencies=["leanclient"],
     lifespan=app_lifespan,
 )

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -10,7 +10,7 @@ import time
 import urllib.request
 from collections.abc import AsyncIterator, Callable, Coroutine, Iterable
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, NoReturn, Optional, cast
 
@@ -26,6 +26,7 @@ from mcp.server.mcpserver import Context, MCPServer
 from mcp.server.mcpserver.utilities.logging import configure_logging, get_logger
 
 from lean_lsp_mcp.client_utils import (
+    get_client,
     _active_transport,
     _project_switching_allowed,
     attach_shared_client,
@@ -114,15 +115,6 @@ async def _urlopen_json(req: urllib.request.Request, timeout: float):
             return orjson.loads(response.read())
 
     return await asyncio.to_thread(_do_request)
-
-
-async def _safe_report_progress(
-    ctx: Context, *, progress: int, total: int, message: str
-) -> None:
-    try:
-        await ctx.report_progress(progress=progress, total=total, message=message)
-    except Exception:
-        return
 
 
 def _parse_disabled_tools(raw_value: str | None) -> set[str]:
@@ -325,6 +317,19 @@ class AppContext:
     repl: Repl | None = None
     repl_enabled: bool = False
     build_coordinator: BuildCoordinator | None = None
+    project_cache: Dict[str, Path | str] = field(default_factory=dict)
+
+
+ToolContext = Context[AppContext, Any]
+
+
+async def _safe_report_progress(
+    ctx: ToolContext, *, progress: int, total: int, message: str
+) -> None:
+    try:
+        await ctx.report_progress(progress=progress, total=total, message=message)
+    except Exception:
+        return
 
 
 _prewarm_started = False
@@ -570,7 +575,7 @@ async def _close_repl_for_project_switch(app_ctx: AppContext) -> None:
 
 
 async def _run_build(
-    ctx: Context,
+    ctx: ToolContext,
     lean_project_path_obj: Path,
     clean: bool,
     fetch_cache: bool,
@@ -1027,7 +1032,7 @@ def _build_attempt_text(
 
 
 async def _multi_attempt_repl(
-    ctx: Context,
+    ctx: ToolContext,
     file_path: str,
     line: int,
     column: Optional[int] = None,
@@ -1158,7 +1163,7 @@ async def _disable_unhealthy_repl(
             logger.exception("REPL close failed after %s failure", operation)
 
 
-async def _run_code_repl(ctx: Context, code: str) -> RunResult | None:
+async def _run_code_repl(ctx: ToolContext, code: str) -> RunResult | None:
     """Run code through the session REPL when its import cache is healthy."""
     app_ctx: AppContext = ctx.request_context.lifespan_context
     if not app_ctx.repl_enabled or app_ctx.repl is None:
@@ -1191,7 +1196,7 @@ async def _run_code_repl(ctx: Context, code: str) -> RunResult | None:
 
 
 async def _multi_attempt_lsp(
-    ctx: Context,
+    ctx: ToolContext,
     file_path: str,
     line: int,
     column: Optional[int] = None,
@@ -1204,7 +1209,7 @@ async def _multi_attempt_lsp(
     if not rel_path:
         _raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     doc = await open_synced(ctx, rel_path)
     original_content = doc.text
 

--- a/src/lean_lsp_mcp/tools/analysis.py
+++ b/src/lean_lsp_mcp/tools/analysis.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 import asyncio
 from typing import Annotated, Dict, List, Optional
 
-from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from lean_lsp_mcp import server
 from lean_lsp_mcp.client_utils import (
+    get_client,
     get_path_policy,
     get_serial_scratch_pool,
     get_scratch_pool,
@@ -44,7 +44,7 @@ from lean_lsp_mcp.models import (
     ),
 )
 async def multi_attempt(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[
         str, Field(description="Absolute or project-root-relative path to Lean file")
     ],
@@ -78,7 +78,7 @@ async def multi_attempt(
     ),
 )
 async def run_code(
-    ctx: Context,
+    ctx: server.ToolContext,
     code: Annotated[str, Field(description="Self-contained Lean code with imports")],
 ) -> RunResult:
     """Run a code snippet and return diagnostics. Must include all imports."""
@@ -116,7 +116,7 @@ async def run_code(
     ),
 )
 async def verify_theorem(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[str, Field(description="Absolute path to Lean file")],
     theorem_name: Annotated[
         str, Field(description="Fully qualified name (e.g. `Namespace.theorem`)")
@@ -206,7 +206,7 @@ async def verify_theorem(
     ),
 )
 async def minimal_hypotheses(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[str, Field(description="Absolute path to Lean file")],
     theorem_name: Annotated[
         str,
@@ -247,7 +247,7 @@ async def minimal_hypotheses(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     doc = await open_synced(ctx, rel_path)
     original_content = doc.text
 
@@ -349,7 +349,7 @@ async def minimal_hypotheses(
     ),
 )
 async def profile_proof(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[
         str, Field(description="Absolute or project-root-relative path to Lean file")
     ],

--- a/src/lean_lsp_mcp/tools/analysis.py
+++ b/src/lean_lsp_mcp/tools/analysis.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 from typing import Annotated, Dict, List, Optional
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 

--- a/src/lean_lsp_mcp/tools/analysis.py
+++ b/src/lean_lsp_mcp/tools/analysis.py
@@ -38,9 +38,9 @@ from lean_lsp_mcp.models import (
     "lean_multi_attempt",
     annotations=ToolAnnotations(
         title="Multi-Attempt",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def multi_attempt(
@@ -72,9 +72,9 @@ async def multi_attempt(
     "lean_run_code",
     annotations=ToolAnnotations(
         title="Run Code",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def run_code(
@@ -110,9 +110,9 @@ async def run_code(
     "lean_verify",
     annotations=ToolAnnotations(
         title="Verify Theorem",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def verify_theorem(
@@ -200,9 +200,9 @@ async def verify_theorem(
     "lean_minimal_hypotheses",
     annotations=ToolAnnotations(
         title="Minimal Hypotheses",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def minimal_hypotheses(
@@ -343,9 +343,9 @@ async def minimal_hypotheses(
     "lean_profile_proof",
     annotations=ToolAnnotations(
         title="Profile Proof",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def profile_proof(

--- a/src/lean_lsp_mcp/tools/build.py
+++ b/src/lean_lsp_mcp/tools/build.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Annotated, Optional
 
-from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
@@ -24,7 +23,7 @@ from lean_lsp_mcp.models import BuildResult
     ),
 )
 async def lsp_build(
-    ctx: Context,
+    ctx: server.ToolContext,
     lean_project_path: Annotated[
         Optional[str], Field(description="Path to Lean project")
     ] = None,

--- a/src/lean_lsp_mcp/tools/build.py
+++ b/src/lean_lsp_mcp/tools/build.py
@@ -17,10 +17,10 @@ from lean_lsp_mcp.models import BuildResult
     "lean_build",
     annotations=ToolAnnotations(
         title="Build Project",
-        readOnlyHint=False,
-        destructiveHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=False,
+        destructive_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def lsp_build(

--- a/src/lean_lsp_mcp/tools/build.py
+++ b/src/lean_lsp_mcp/tools/build.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated, Optional
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 

--- a/src/lean_lsp_mcp/tools/diagnostics.py
+++ b/src/lean_lsp_mcp/tools/diagnostics.py
@@ -44,9 +44,9 @@ def _flatten_severity_schema(schema: dict) -> None:
     "lean_file_outline",
     annotations=ToolAnnotations(
         title="File Outline",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def file_outline(
@@ -72,9 +72,9 @@ async def file_outline(
     "lean_diagnostic_messages",
     annotations=ToolAnnotations(
         title="Diagnostics",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def diagnostic_messages(
@@ -186,9 +186,9 @@ async def diagnostic_messages(
     "lean_code_actions",
     annotations=ToolAnnotations(
         title="Code Actions",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def code_actions(

--- a/src/lean_lsp_mcp/tools/diagnostics.py
+++ b/src/lean_lsp_mcp/tools/diagnostics.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 from typing import Annotated, Literal, Optional
 
-from leanclient.aio import AsyncLeanLSPClient
 from leanclient.aio.convert import range_from_utf16
-from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from lean_lsp_mcp import server
-from lean_lsp_mcp.client_utils import get_serial_scratch_pool, open_synced
+from lean_lsp_mcp.client_utils import get_client, get_serial_scratch_pool, open_synced
 from lean_lsp_mcp.models import (
     CodeAction,
     CodeActionEdit,
@@ -50,7 +48,7 @@ def _flatten_severity_schema(schema: dict) -> None:
     ),
 )
 async def file_outline(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[
         str, Field(description="Absolute or project-root-relative path to Lean file")
     ],
@@ -63,7 +61,7 @@ async def file_outline(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     pool = get_serial_scratch_pool(ctx)
     return await generate_outline_data(client, pool, rel_path, max_declarations)
 
@@ -78,7 +76,7 @@ async def file_outline(
     ),
 )
 async def diagnostic_messages(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[
         str, Field(description="Absolute or project-root-relative path to Lean file")
     ],
@@ -125,7 +123,7 @@ async def diagnostic_messages(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     await open_synced(ctx, rel_path)
 
     # If declaration_name is provided, get its range and use that for filtering
@@ -192,7 +190,7 @@ async def diagnostic_messages(
     ),
 )
 async def code_actions(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[str, Field(description="Absolute path to Lean file")],
     line: Annotated[int, Field(description="Line number (1-indexed)", ge=1)],
 ) -> CodeActionsResult:
@@ -201,7 +199,7 @@ async def code_actions(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     await open_synced(ctx, rel_path)
 
     report = await client.diagnostics(rel_path)

--- a/src/lean_lsp_mcp/tools/diagnostics.py
+++ b/src/lean_lsp_mcp/tools/diagnostics.py
@@ -6,7 +6,7 @@ from typing import Annotated, Literal, Optional
 
 from leanclient.aio import AsyncLeanLSPClient
 from leanclient.aio.convert import range_from_utf16
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 

--- a/src/lean_lsp_mcp/tools/goals.py
+++ b/src/lean_lsp_mcp/tools/goals.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 from typing import Annotated, Literal, Optional
 
-from leanclient.aio import AsyncLeanLSPClient, LeanRequestTimeout
-from mcp.server.mcpserver import Context
+from leanclient.aio import LeanRequestTimeout
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from lean_lsp_mcp import server
-from lean_lsp_mcp.client_utils import open_synced
+from lean_lsp_mcp.client_utils import get_client, open_synced
 from lean_lsp_mcp.models import GoalState, StructuredGoal, TermGoalState
 
 
@@ -24,7 +23,7 @@ from lean_lsp_mcp.models import GoalState, StructuredGoal, TermGoalState
     ),
 )
 async def goal(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[
         str, Field(description="Absolute or project-root-relative path to Lean file")
     ],
@@ -59,7 +58,7 @@ async def goal(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     await open_synced(ctx, rel_path)
     content = client.content(rel_path)
     lines = content.splitlines()
@@ -118,7 +117,7 @@ async def goal(
     ),
 )
 async def term_goal(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[
         str, Field(description="Absolute or project-root-relative path to Lean file")
     ],
@@ -132,7 +131,7 @@ async def term_goal(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     await open_synced(ctx, rel_path)
     content = client.content(rel_path)
     lines = content.splitlines()

--- a/src/lean_lsp_mcp/tools/goals.py
+++ b/src/lean_lsp_mcp/tools/goals.py
@@ -18,9 +18,9 @@ from lean_lsp_mcp.models import GoalState, StructuredGoal, TermGoalState
     "lean_goal",
     annotations=ToolAnnotations(
         title="Proof Goals",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def goal(
@@ -112,9 +112,9 @@ async def goal(
     "lean_term_goal",
     annotations=ToolAnnotations(
         title="Term Goal",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def term_goal(

--- a/src/lean_lsp_mcp/tools/goals.py
+++ b/src/lean_lsp_mcp/tools/goals.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Annotated, Literal, Optional
 
 from leanclient.aio import AsyncLeanLSPClient, LeanRequestTimeout
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 

--- a/src/lean_lsp_mcp/tools/navigation.py
+++ b/src/lean_lsp_mcp/tools/navigation.py
@@ -34,9 +34,9 @@ from lean_lsp_mcp.utils import (
     "lean_hover_info",
     annotations=ToolAnnotations(
         title="Hover Info",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def hover(
@@ -85,9 +85,9 @@ async def hover(
     "lean_completions",
     annotations=ToolAnnotations(
         title="Completions",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def completions(
@@ -183,9 +183,9 @@ async def completions(
     "lean_declaration_file",
     annotations=ToolAnnotations(
         title="Declaration Source",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def declaration_file(
@@ -278,9 +278,9 @@ async def declaration_file(
     "lean_references",
     annotations=ToolAnnotations(
         title="Find References",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def references(

--- a/src/lean_lsp_mcp/tools/navigation.py
+++ b/src/lean_lsp_mcp/tools/navigation.py
@@ -7,13 +7,11 @@ import re
 from pathlib import Path
 from typing import Annotated, List, Optional
 
-from leanclient.aio import AsyncLeanLSPClient
-from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from lean_lsp_mcp import server
-from lean_lsp_mcp.client_utils import get_path_policy, open_synced
+from lean_lsp_mcp.client_utils import get_client, get_path_policy, open_synced
 from lean_lsp_mcp.models import (
     CompletionItem,
     CompletionsResult,
@@ -40,7 +38,7 @@ from lean_lsp_mcp.utils import (
     ),
 )
 async def hover(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[
         str, Field(description="Absolute or project-root-relative path to Lean file")
     ],
@@ -55,7 +53,7 @@ async def hover(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     await open_synced(ctx, rel_path)
     file_content = client.content(rel_path)
     hover_info = await client.hover(rel_path, line - 1, column - 1)
@@ -91,7 +89,7 @@ async def hover(
     ),
 )
 async def completions(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[
         str, Field(description="Absolute or project-root-relative path to Lean file")
     ],
@@ -110,7 +108,7 @@ async def completions(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     await open_synced(ctx, rel_path)
     content = client.content(rel_path)
     raw_completions = await client.completions(rel_path, line - 1, column - 1)
@@ -189,7 +187,7 @@ async def completions(
     ),
 )
 async def declaration_file(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[
         str, Field(description="Absolute or project-root-relative path to Lean file")
     ],
@@ -211,7 +209,7 @@ async def declaration_file(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     await open_synced(ctx, rel_path)
     orig_file_content = client.content(rel_path)
 
@@ -284,7 +282,7 @@ async def declaration_file(
     ),
 )
 async def references(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[str, Field(description="Absolute path to Lean file")],
     line: Annotated[int, Field(description="Line number (1-indexed)", ge=1)],
     column: Annotated[
@@ -302,7 +300,7 @@ async def references(
             "Invalid Lean file path: Unable to start LSP server or load file"
         )
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     await open_synced(ctx, rel_path)
 
     try:

--- a/src/lean_lsp_mcp/tools/navigation.py
+++ b/src/lean_lsp_mcp/tools/navigation.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Annotated, List, Optional
 
 from leanclient.aio import AsyncLeanLSPClient
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 

--- a/src/lean_lsp_mcp/tools/search.py
+++ b/src/lean_lsp_mcp/tools/search.py
@@ -11,7 +11,7 @@ from typing import Annotated, List, Literal, Optional
 
 import orjson
 from leanclient.aio import AsyncLeanLSPClient
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 

--- a/src/lean_lsp_mcp/tools/search.py
+++ b/src/lean_lsp_mcp/tools/search.py
@@ -46,9 +46,9 @@ class LocalSearchError(Exception):
     "lean_local_search",
     annotations=ToolAnnotations(
         title="Local Search",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def local_search(
@@ -107,9 +107,9 @@ async def local_search(
     "lean_leansearch",
     annotations=ToolAnnotations(
         title="LeanSearch",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=True,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=True,
     ),
 )
 # leansearch.net raised capacity to ~40 req/s (per-IP ~120 req/min) and asked
@@ -162,9 +162,9 @@ async def leansearch(
     "lean_loogle",
     annotations=ToolAnnotations(
         title="Loogle",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=True,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=True,
     ),
 )
 async def loogle(
@@ -237,9 +237,9 @@ async def loogle(
     "lean_leanfinder",
     annotations=ToolAnnotations(
         title="Lean Finder",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=True,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=True,
     ),
 )
 @server.rate_limited("leanfinder", *config.RATE_LIMITS["leanfinder"])
@@ -299,9 +299,9 @@ async def leanfinder(
     "lean_state_search",
     annotations=ToolAnnotations(
         title="State Search",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=True,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=True,
     ),
 )
 @server.rate_limited(
@@ -358,9 +358,9 @@ async def state_search(
     "lean_hammer_premise",
     annotations=ToolAnnotations(
         title="Hammer Premises",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=True,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=True,
     ),
 )
 @server.rate_limited(

--- a/src/lean_lsp_mcp/tools/search.py
+++ b/src/lean_lsp_mcp/tools/search.py
@@ -10,13 +10,12 @@ from pathlib import Path
 from typing import Annotated, List, Literal, Optional
 
 import orjson
-from leanclient.aio import AsyncLeanLSPClient
-from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from lean_lsp_mcp import config, server
 from lean_lsp_mcp.client_utils import (
+    get_client,
     bind_lean_project_path,
     build_lean_path_policy,
     open_synced,
@@ -52,7 +51,7 @@ class LocalSearchError(Exception):
     ),
 )
 async def local_search(
-    ctx: Context,
+    ctx: server.ToolContext,
     query: Annotated[str, Field(description="Declaration name or prefix")],
     limit: Annotated[int, Field(description="Max matches", ge=1)] = 10,
     project_root: Annotated[
@@ -118,7 +117,7 @@ async def local_search(
 # per-IP limit, which the maintainers adjust dynamically as capacity allows.
 @server.rate_limited("leansearch", *config.RATE_LIMITS["leansearch"])
 async def leansearch(
-    ctx: Context,
+    ctx: server.ToolContext,
     query: Annotated[str, Field(description="Natural language or Lean term query")],
     num_results: Annotated[int, Field(description="Max results", ge=1)] = 5,
 ) -> LeanSearchResults:
@@ -168,7 +167,7 @@ async def leansearch(
     ),
 )
 async def loogle(
-    ctx: Context,
+    ctx: server.ToolContext,
     query: Annotated[
         str, Field(description="Type pattern, constant, or name substring")
     ],
@@ -244,7 +243,7 @@ async def loogle(
 )
 @server.rate_limited("leanfinder", *config.RATE_LIMITS["leanfinder"])
 async def leanfinder(
-    ctx: Context,
+    ctx: server.ToolContext,
     query: Annotated[str, Field(description="Mathematical concept or proof state")],
     num_results: Annotated[int, Field(description="Max results", ge=1)] = 5,
     version: Annotated[
@@ -312,7 +311,7 @@ async def leanfinder(
     ),
 )
 async def state_search(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[
         str, Field(description="Absolute or project-root-relative path to Lean file")
     ],
@@ -325,7 +324,7 @@ async def state_search(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     await open_synced(ctx, rel_path)
     goal = await client.goal(rel_path, line - 1, column - 1)
 
@@ -369,7 +368,7 @@ async def state_search(
     bypass=lambda: server._custom_backend("LEAN_HAMMER_URL", config.DEFAULT_HAMMER_URL),
 )
 async def hammer_premise(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[
         str, Field(description="Absolute or project-root-relative path to Lean file")
     ],
@@ -385,7 +384,7 @@ async def hammer_premise(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     await open_synced(ctx, rel_path)
     goal = await client.goal(rel_path, line - 1, column - 1)
 

--- a/src/lean_lsp_mcp/tools/widgets.py
+++ b/src/lean_lsp_mcp/tools/widgets.py
@@ -18,9 +18,9 @@ from lean_lsp_mcp.models import WidgetsResult, WidgetSourceResult
     "lean_get_widgets",
     annotations=ToolAnnotations(
         title="Get Widgets",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def get_widgets(
@@ -44,9 +44,9 @@ async def get_widgets(
     "lean_get_widget_source",
     annotations=ToolAnnotations(
         title="Widget Source",
-        readOnlyHint=True,
-        idempotentHint=True,
-        openWorldHint=False,
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=False,
     ),
 )
 async def get_widget_source(

--- a/src/lean_lsp_mcp/tools/widgets.py
+++ b/src/lean_lsp_mcp/tools/widgets.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from leanclient.aio import AsyncLeanLSPClient
-from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from lean_lsp_mcp import server
-from lean_lsp_mcp.client_utils import open_synced
+from lean_lsp_mcp.client_utils import get_client, open_synced
 from lean_lsp_mcp.models import WidgetsResult, WidgetSourceResult
 
 
@@ -24,7 +22,7 @@ from lean_lsp_mcp.models import WidgetsResult, WidgetSourceResult
     ),
 )
 async def get_widgets(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[str, Field(description="Absolute path to Lean file")],
     line: Annotated[int, Field(description="Line number (1-indexed)", ge=1)],
     column: Annotated[int, Field(description="Column number (1-indexed)", ge=1)],
@@ -34,7 +32,7 @@ async def get_widgets(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     await open_synced(ctx, rel_path)
     widgets = await client.get_widgets(rel_path, line - 1, column - 1)
     return WidgetsResult(widgets=widgets)
@@ -50,7 +48,7 @@ async def get_widgets(
     ),
 )
 async def get_widget_source(
-    ctx: Context,
+    ctx: server.ToolContext,
     file_path: Annotated[str, Field(description="Absolute path to Lean file")],
     javascript_hash: Annotated[
         str, Field(description="javascriptHash from a widget instance")
@@ -61,7 +59,7 @@ async def get_widget_source(
     if not rel_path:
         server._raise_invalid_path(file_path)
 
-    client: AsyncLeanLSPClient = ctx.request_context.lifespan_context.client
+    client = get_client(ctx)
     await open_synced(ctx, rel_path, wait=True)
     source = await client.get_widget_source(rel_path, 0, 0, javascript_hash)
     if source is None:

--- a/src/lean_lsp_mcp/tools/widgets.py
+++ b/src/lean_lsp_mcp/tools/widgets.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from leanclient.aio import AsyncLeanLSPClient
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import Field
 

--- a/tests/helpers/mcp_client.py
+++ b/tests/helpers/mcp_client.py
@@ -54,7 +54,7 @@ class MCPClient:
         """Call a tool and optionally assert success."""
 
         result = await self._session.call_tool(name, arguments or {})
-        if result.isError and not expect_error:
+        if result.is_error and not expect_error:
             raise MCPToolError(name, result)
         return result
 

--- a/tests/manual/drive.py
+++ b/tests/manual/drive.py
@@ -54,7 +54,7 @@ async def main():
                     async def one(c):
                         t = time.time()
                         res = await sess.call_tool(c["tool"], c.get("args", {}))
-                        return c.get("label", c["tool"]), time.time() - t, res.isError
+                        return c.get("label", c["tool"]), time.time() - t, res.is_error
 
                     t = time.time()
                     results = await asyncio.gather(*(one(c) for c in call["gather"]))
@@ -71,7 +71,7 @@ async def main():
                     )
                     dt = time.time() - t
                     out = "\n".join(c.text for c in res.content if hasattr(c, "text"))
-                    print(f"[{dt:7.2f}s] {label} isError={res.isError} len={len(out)}")
+                    print(f"[{dt:7.2f}s] {label} isError={res.is_error} len={len(out)}")
                     maxlen = call.get("show", 400)
                     print("    " + out[:maxlen].replace("\n", "\n    "))
                     if len(out) > maxlen:

--- a/tests/test_diagnostic_line_range.py
+++ b/tests/test_diagnostic_line_range.py
@@ -13,8 +13,8 @@ from tests.helpers.mcp_client import MCPClient, MCPToolError, result_text
 
 def parse_diagnostics_result(result) -> list[dict]:
     """Parse diagnostics result, handling both structured and text formats."""
-    if result.structuredContent is not None:
-        sc = result.structuredContent
+    if result.structured_content is not None:
+        sc = result.structured_content
         # FastMCP may wrap under a 'result' key
         if "result" in sc and isinstance(sc["result"], dict):
             sc = sc["result"]

--- a/tests/test_minimal_hypotheses.py
+++ b/tests/test_minimal_hypotheses.py
@@ -125,4 +125,4 @@ async def test_minimal_hypotheses_unknown_theorem(
             },
             expect_error=True,
         )
-        assert result.isError
+        assert result.is_error

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -16,8 +16,8 @@ def _first_result_item(result) -> dict[str, str] | None:
     Handles both structured content and text content formats.
     """
     # Try structured content first (new format)
-    if result.structuredContent is not None:
-        items = result.structuredContent.get("items", [])
+    if result.structured_content is not None:
+        items = result.structured_content.get("items", [])
         return items[0] if items else None
 
     # Fall back to parsing text content

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -59,11 +59,11 @@ async def test_diagnostics_structured_output_not_double_encoded(
         )
 
         # structuredContent should be present
-        assert result.structuredContent is not None, (
+        assert result.structured_content is not None, (
             "Tool should return structured content"
         )
 
-        structured = result.structuredContent
+        structured = result.structured_content
 
         # FastMCP may wrap the model under a 'result' key
         if "result" in structured and isinstance(structured["result"], dict):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -105,4 +105,4 @@ async def test_verify_nonexistent_theorem(
             },
             expect_error=True,
         )
-        assert result.isError
+        assert result.is_error

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -982,13 +982,13 @@ def test_diagnostic_messages_severity_schema_is_vertex_compatible() -> None:
     """
     tools = asyncio.run(server.mcp.list_tools())
     tool = next(t for t in tools if t.name == "lean_diagnostic_messages")
-    severity = tool.inputSchema["properties"]["severity"]
+    severity = tool.input_schema["properties"]["severity"]
     severity_json = json.dumps(severity)
 
     assert severity.get("type") == "string"
     assert "anyOf" not in severity
     assert "$ref" not in severity_json
-    assert "DiagnosticSeverity" not in json.dumps(tool.inputSchema.get("$defs", {}))
+    assert "DiagnosticSeverity" not in json.dumps(tool.input_schema.get("$defs", {}))
     assert severity.get("enum") == ["error", "warning", "info", "hint"]
     for level in ("error", "warning", "info", "hint"):
         assert level in severity_json

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -367,7 +367,7 @@ def test_load_tool_description_overrides_inline(
 def test_apply_tool_configuration_disables_and_overrides(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    mcp = server.FastMCP(name="test", instructions="base instructions")
+    mcp = server.MCPServer(name="test", instructions="base instructions")
 
     @mcp.tool("enabled_tool")
     def enabled_tool() -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -1,12 +1,13 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
     "python_full_version < '3.11' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 
@@ -262,7 +263,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -279,40 +280,42 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
     { name = "h11" },
+    { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
     { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2-jsfetch"
+version = "1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -363,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "lean-lsp-mcp"
-version = "0.28.1"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },
@@ -394,7 +397,7 @@ requires-dist = [
     { name = "anyio", marker = "extra == 'dev'", specifier = ">=4.14.2" },
     { name = "certifi", specifier = ">=2026.7.22" },
     { name = "leanclient", specifier = ">=0.13.0" },
-    { name = "mcp", extras = ["cli"], specifier = "==1.28.1" },
+    { name = "mcp", extras = ["cli"], specifier = "==2.0.0" },
     { name = "orjson", specifier = ">=3.11.9" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.4.0" },
@@ -435,15 +438,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -453,9 +456,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
 ]
 
 [package.optional-dependencies]
@@ -465,12 +468,37 @@ cli = [
 ]
 
 [[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -738,20 +766,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -1093,7 +1107,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
 wheels = [
@@ -1338,6 +1353,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates `mcp` to 2.0.0, implementing [the new MCP spec](https://blog.modelcontextprotocol.io/posts/2026-07-28/).

Two notes:
- The new spec deprecates the `sse` transport. It's kept working here but thought it was worth mentioning in case you want to handle it differently.
- 2.0.0 removes sessions from the protocol, so new-spec HTTP clients share one process-wide REPL. The internal lock already serializes access, so this only affects throughput (stdio is unaffected). Happy to open another PR giving each project its own REPL like the LSP client does.

PR generated with help from Fable in Claude Code.