### PR TITLE
Fix lean_profile_proof cleanup crash on Windows

### DIFF
--- a/src/lean_lsp_mcp/profile_utils.py
+++ b/src/lean_lsp_mcp/profile_utils.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import platform
 import re
 import tempfile
 from collections import defaultdict
@@ -147,10 +148,18 @@ def _filter_categories(cumulative: dict[str, float]) -> dict[str, float]:
     }
 
 
-def _kill_process_group(pid: int) -> None:
-    """Kill an entire process group. No-op if already dead."""
+def _kill_process_group(proc: asyncio.subprocess.Process) -> None:
+    """Kill an entire process group. No-op if already dead.
+
+    Windows has no POSIX process groups and no os.killpg/os.getpgid, so
+    killing the process itself is the available equivalent there.  Same
+    branch Repl.close uses for this cleanup.
+    """
     try:
-        os.killpg(os.getpgid(pid), 9)
+        if platform.system() != "Windows":
+            os.killpg(os.getpgid(proc.pid), 9)
+        else:
+            proc.kill()
     except (ProcessLookupError, OSError):
         pass
 
@@ -181,7 +190,7 @@ async def _run_lean_profile(file_path: Path, project_path: Path, timeout: float)
     except asyncio.TimeoutError:
         raise TimeoutError(f"Profiling timed out after {timeout}s")
     finally:
-        _kill_process_group(proc.pid)
+        _kill_process_group(proc)
 
 
 def _find_proof_start(source_lines: list[str]) -> int:

--- a/tests/unit/test_profile_utils.py
+++ b/tests/unit/test_profile_utils.py
@@ -1,13 +1,19 @@
 """Unit tests for profile_utils module."""
 
+import os
+import platform
+from pathlib import Path
+
 import pytest
 
+from lean_lsp_mcp import profile_utils
 from lean_lsp_mcp.profile_utils import (
     _build_proof_items,
     _extract_line_times,
     _extract_theorem_source,
     _filter_categories,
     _parse_output,
+    _run_lean_profile,
 )
 
 
@@ -109,3 +115,70 @@ class TestFilterCategories:
     def test_filters_skip_and_small(self):
         cumulative = {"import": 100.0, "simp": 5.0, "parsing": 2.0, "ring": 0.5}
         assert _filter_categories(cumulative) == {"simp": 5.0}
+
+
+class _FakeProc:
+    """Stands in for the `lake env lean --profile` subprocess."""
+
+    pid = 4321
+
+    def __init__(self):
+        self.killed = False
+
+    async def communicate(self):
+        return b"[Elab.command] [0.005] done\n", None
+
+    def kill(self):
+        self.killed = True
+
+
+class TestRunLeanProfileCleanup:
+    """The cleanup in _run_lean_profile's `finally` runs on every profile.
+
+    Both platforms are simulated rather than detected, so each case is
+    exercised wherever the suite runs.
+    """
+
+    @pytest.fixture
+    def proc(self, monkeypatch) -> _FakeProc:
+        fake = _FakeProc()
+
+        async def fake_exec(*args, **kwargs):
+            return fake
+
+        monkeypatch.setattr(profile_utils.asyncio, "create_subprocess_exec", fake_exec)
+        return fake
+
+    async def test_windows_kills_the_process_instead_of_the_group(
+        self, monkeypatch, tmp_path: Path, proc: _FakeProc
+    ):
+        """Windows has no os.killpg, so the group kill must not be attempted.
+
+        Calling it raised AttributeError out of the `finally`, which discarded
+        the profile that had already been produced.
+        """
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        monkeypatch.delattr(os, "killpg", raising=False)
+        monkeypatch.delattr(os, "getpgid", raising=False)
+
+        output = await _run_lean_profile(tmp_path / "T.lean", tmp_path, 30.0)
+
+        assert output == "[Elab.command] [0.005] done\n"
+        assert proc.killed
+
+    async def test_posix_still_kills_the_whole_group(
+        self, monkeypatch, tmp_path: Path, proc: _FakeProc
+    ):
+        """The group kill is what stops lean surviving as an orphan."""
+        killed: list[tuple[int, int]] = []
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(os, "getpgid", lambda pid: pid, raising=False)
+        monkeypatch.setattr(
+            os, "killpg", lambda pgid, sig: killed.append((pgid, sig)), raising=False
+        )
+
+        output = await _run_lean_profile(tmp_path / "T.lean", tmp_path, 30.0)
+
+        assert output == "[Elab.command] [0.005] done\n"
+        assert killed == [(_FakeProc.pid, 9)]
+        assert not proc.killed


### PR DESCRIPTION
Fixes #216.

## Summary

Every `lean_profile_proof` call on Windows fails with `module 'os' has no attribute 'killpg'`, raised from `_run_lean_profile`'s `finally` after the profile output has already been produced. `_kill_process_group` calls `os.killpg(os.getpgid(pid), 9)`, neither function exists on Windows, and `AttributeError` isn't caught by the `except (ProcessLookupError, OSError)` guard.

The fix branches the cleanup exactly the way `Repl.close` already does elsewhere in this codebase: POSIX kills the process group (unchanged), Windows kills the process itself. `_kill_process_group` now takes the `Process` object so the Windows branch can use `proc.kill()`.

## Testing

Both platforms are simulated in the new tests (monkeypatched `platform.system` and `os.killpg`/`os.getpgid`, fake subprocess), so each case runs wherever the suite runs:

- On current `main`'s `profile_utils.py`, the Windows-case test fails with the exact reported error — `AttributeError: module 'os' has no attribute 'killpg'` out of `profile_utils.py`'s cleanup — and the POSIX-case test passes (that behavior is unchanged).
- With this fix: `tests/unit/test_profile_utils.py` → 15 passed (13 existing + these 2).
- Full `tests/unit` on this machine (native Windows 11, Python 3.13): 8 failures in other modules (`test_cli`, `test_client_utils`, `test_file_utils`, `test_loogle`, `test_server` path/env-sanitization cases) are identical with and without this change — pre-existing local-environment failures, not introduced here. The only delta is the new Windows-case test flipping fail → pass.

Limit worth stating: I haven't run the end-to-end `lean_profile_proof` tool call on this machine (no Lake project wired up here); the reporter's traceback places the crash in this cleanup path, which the tests exercise through `_run_lean_profile`'s real `finally`.
