### PR TITLE
Bind profile lines back to their source

### DIFF
--- a/src/lean_lsp_mcp/profile_utils.py
+++ b/src/lean_lsp_mcp/profile_utils.py
@@ -10,6 +10,12 @@ from pathlib import Path
 from lean_lsp_mcp.models import LineProfile, ProofProfileResult
 
 _TRACE_RE = re.compile(r"^(\s*)\[([^\]]+)\]\s+\[([\d.]+)\]\s+(.+)$")
+# Every trace message is prefixed with the status of the traced action: Lean's
+# `TraceResult.toEmoji` renders success as U+2705, failure as U+274C and error
+# as U+1F4A5, each followed by the variation selector U+FE0F. The prefix has to
+# come off before a message can be compared against source text, or tested for
+# a known lead such as "expected type:".
+_TRACE_STATUS_RE = re.compile("^(?:\\u2705|\\u274c|\\U0001f4a5)\\ufe0f?\\s*")
 _CUMULATIVE_RE = re.compile(r"^\s+(\S+(?:\s+\S+)*)\s+([\d.]+)(ms|s)$")
 _DECL_RE = re.compile(r"^\s*(?:private\s+)?(theorem|lemma|def)\s+(\S+)")
 _HEADER_RE = re.compile(r"^(import|open|set_option|universe|variable)\s")
@@ -127,13 +133,21 @@ def _extract_line_times(
         elif in_value:
             if depth <= value_depth:
                 break
-            if cls == "Elab.step" and not msg.startswith("expected type:"):
-                tactic_depth = tactic_depth or depth
-                if depth == tactic_depth:
-                    tactic = msg.split("\n")[0].strip().lstrip("·*- \t")
-                    if ln := _match_line(tactic, not tactic, proof_items, used):
-                        line_times[ln] += ms
-                        used.add(ln)
+            if cls == "Elab.step":
+                head = _TRACE_STATUS_RE.sub("", msg.split("\n")[0].strip(), count=1)
+                # A step whose message is only the status prefix carries no
+                # tactic: those are the wrappers Lean emits around a tactic
+                # block. Skipping them before the depth is fixed is what lets
+                # the first real tactic set it, and stops an empty message from
+                # matching an arbitrary line (`content.startswith("")` is true
+                # for every line, and a bullet is matched on position alone).
+                if head and not head.startswith("expected type:"):
+                    tactic_depth = tactic_depth or depth
+                    if depth == tactic_depth:
+                        tactic = head.lstrip("·*- \t")
+                        if ln := _match_line(tactic, not tactic, proof_items, used):
+                            line_times[ln] += ms
+                            used.add(ln)
 
     return dict(line_times), total
 

--- a/tests/unit/test_profile_utils.py
+++ b/tests/unit/test_profile_utils.py
@@ -10,6 +10,12 @@ from lean_lsp_mcp.profile_utils import (
     _parse_output,
 )
 
+# Status markers exactly as `lean --profile` emits them, captured from a real
+# run rather than written by hand: success, failure, error.
+OK = "\u2705\ufe0f"
+FAIL = "\u274c\ufe0f"
+ERROR = "\U0001f4a5\ufe0f"
+
 
 class TestParseOutput:
     def test_parses_single_trace(self):
@@ -81,6 +87,76 @@ class TestExtractLineTimes:
         line_times, total = _extract_line_times(traces, "missing", [])
         assert line_times == {}
         assert total == 0.0
+
+
+class TestTraceStatusMarkers:
+    """Messages arrive prefixed with the traced action's status emoji.
+
+    The cases below use the marked form the profiler actually produces. The
+    unmarked form used elsewhere in this file matches whatever the parser
+    happens to do, which is why it never caught the prefix.
+    """
+
+    @pytest.mark.parametrize("marker", [OK, FAIL, ERROR], ids=["ok", "fail", "error"])
+    def test_binds_a_tactic_whatever_its_status(self, marker):
+        """With the marker left in place no message can match any source line,
+        and a step that failed or threw still spent its time on that line."""
+        traces = [
+            (0, "Elab.definition.value", 10.0, "my_thm"),
+            (1, "Elab.step", 8.0, f"{marker} induction n with"),
+        ]
+        proof_items = [(2, "induction n with", False)]
+
+        line_times, _ = _extract_line_times(traces, "my_thm", proof_items)
+
+        assert line_times == {2: 8.0}
+
+    def test_keeps_a_leading_parenthesis(self):
+        """Tactic text can start with punctuation, so only the status marker
+        may be removed."""
+        traces = [
+            (0, "Elab.definition.value", 10.0, "my_thm"),
+            (1, "Elab.step", 4.0, f"{OK} (rewrite [h])"),
+        ]
+        proof_items = [(2, "(rewrite [h])", False)]
+
+        line_times, _ = _extract_line_times(traces, "my_thm", proof_items)
+
+        assert line_times == {2: 4.0}
+
+    def test_a_status_only_step_claims_nothing(self):
+        """Lean wraps a tactic block in steps whose message is only the status
+        prefix, and they arrive before any real tactic.
+
+        Such a step must not take a line: an empty message matches a bullet on
+        position alone, and matches any line at all through
+        `content.startswith("")`. Skipping it is also what lets the first real
+        tactic fix the depth the others are matched at.
+        """
+        traces = [
+            (0, "Elab.definition.value", 10.0, "my_thm"),
+            (1, "Elab.step", 9.0, OK),
+            (2, "Elab.step", 8.0, f"{OK} norm_num"),
+        ]
+        proof_items = [(2, "exact hp", True), (3, "norm_num", True)]
+
+        line_times, _ = _extract_line_times(traces, "my_thm", proof_items)
+
+        assert line_times == {3: 8.0}
+
+    def test_marked_expected_type_does_not_claim_the_tactic_depth(self):
+        """The `expected type:` guard has to see the message without its marker,
+        otherwise a pseudo step fixes the depth that real tactics are matched at."""
+        traces = [
+            (0, "Elab.definition.value", 10.0, "my_thm"),
+            (1, "Elab.step", 5.0, f"{OK} expected type: Prop, term"),
+            (2, "Elab.step", 8.0, f"{OK} ring"),
+        ]
+        proof_items = [(2, "ring", False)]
+
+        line_times, _ = _extract_line_times(traces, "my_thm", proof_items)
+
+        assert line_times == {2: 8.0}
 
 
 class TestExtractTheoremSource:


### PR DESCRIPTION
Fixes #220.

## The problem

`_extract_line_times` matches trace messages against source lines, but every message arrives prefixed with the status of the traced action. Lean's `TraceResult.toEmoji` renders success, failure and error as `U+2705`, `U+274C` and `U+1F4A5`, each followed by `U+FE0F`, so a step reads `✅️ rw [h]` rather than `rw [h]`. Neither direction of the comparison in `_match_line` can fire, and `lines` comes back empty for every proof while `ms` and `categories` look normal.

## Two further effects of the same prefix

**The `expected type:` guard never fired.** It tested `msg.startswith("expected type:")` on a message that begins with the emoji, so it excluded nothing. It now tests the message with the prefix removed.

**A status only message is not a tactic.** Lean wraps a tactic block in steps whose message is just the prefix. Removing the prefix leaves those empty, and an empty message is dangerous in two separate ways: `_match_line` matches a bullet on position alone, and `content.startswith("")` is true for every line. On a proof with a cheap bullet and an expensive one, an early wrapper took the whole proof's time and put it on the cheap line. Those steps also arrive before any real tactic, so one of them fixed `tactic_depth` at a level where no tactic lives, which is why a proof like

```lean
have h1 : x ≥ 6 := hx
have h2 : y ≥ 4 := hy
omega
```

still bound nothing even with the prefix stripped.

Skipping messages that carry no tactic solves both: the first real tactic fixes the depth, and nothing is attributed on position.

## Effect, measured on this repo's own fixture

`tests/test_project/ProfileTest.lean`, every theorem reporting `lines: []` before:

| theorem | after |
| --- | --- |
| `simple_by` | `[(4, 11.7, 'rw [h]')]` |
| `simp_test` | `[(7, 16.8, 'simp')]` |
| `omega_test` | `[(10, 15.9, 'omega')]` |
| `multi_step` | `[(16, 17.1, 'omega'), (14, 6.0, 'have h1 …'), (15, 4.0, 'have h2 …')]` |

Lines 4 and 10 are what `tests/test_profile.py` asserts when `lines` is non empty, so those assertions now run rather than being skipped.

Bullets bind through their content once the wrappers stop claiming the depth, which also means the attribution is right. A proof of `· exact hp` on line 5 and `· norm_num` on line 6, the second deliberately expensive:

```
line_times = {4: 2.7, 5: 1.4, 6: 425.6}
```

## Testing

Six new tests in `tests/unit/test_profile_utils.py`, built from messages captured from a real `lean --profile` run rather than written by hand. The existing tests in that file use unmarked messages, which is why they stayed green while nothing matched.

`tests/unit` on `main`: 5 failed, 266 passed, 1 skipped. With this change: 5 failed, 272 passed, 1 skipped. Same five failures both sides, all pre-existing on this machine, and the delta is exactly this PR's tests. Reverting `src/lean_lsp_mcp/profile_utils.py` to `main` while keeping the new tests gives 6 failed, 13 passed, so they discriminate the change.

`ruff check` and `ruff format --check` are clean. Windows 11, Python 3.12.1, Lean 4.30.0 for the test project.

## What I could not run

`tests/test_profile.py` calls `profile_theorem` directly, which on Windows hits the `os.killpg` crash in #216, so I applied the fix from #218 locally to get past it. With that applied, four of its six tests fail with `Profiling timed out after 60.0s`, and the same tests fail identically on `main` when run in isolation, so the timeout is this machine rather than the change. The numbers in the table above come from calling `profile_theorem` directly with a longer timeout.
